### PR TITLE
Test redirect

### DIFF
--- a/test/signon.spec.js
+++ b/test/signon.spec.js
@@ -281,7 +281,7 @@ describe("signup", () => {
   });
 });
 
-describe("login", () => {
+describe.only("login", () => {
   afterEach(() => {
     window.location.assign.mockClear();
   });
@@ -376,14 +376,15 @@ describe("login", () => {
     it("should login and redirect to a provided path", async () => {
       axios.post.mockImplementationOnce(() => mockResponse);
 
-      // Call login() with redirect = false
+      // Call login() with redirect URL
+      const redirectUrl = `https://api.userfront.com/v0/tenants/${tenantId}/auth/saml/idp/login`;
       const payload = {
         emailOrUsername: idTokenUserDefaults.email,
         password: "something",
       };
       await login({
         method: "password",
-        redirect: false,
+        redirect: redirectUrl,
         ...payload,
       });
 
@@ -404,7 +405,7 @@ describe("login", () => {
       expect(Userfront.user.userId).toEqual(idTokenUserDefaults.userId);
 
       // Should have redirected correctly
-      expect(window.location.assign).not.toHaveBeenCalled();
+      expect(window.location.assign).toHaveBeenCalledWith(redirectUrl);
     });
 
     it("password method error should respond with whatever error the server sends", async () => {


### PR DESCRIPTION
I'm confused about this test (`"should login and redirect to a provided path"`), I think there may have been a copy+paste hiccup when the test was written. 

When the `redirect` parameter is changed from `false`


```js
await login({
  method: "password",
  redirect: false,
  ...payload,
});
```

to a URL (`"https://api.userfront.com/v0/tenants/abcd9876/auth/saml/idp/login"`)

```js
await login({
  method: "password",
  redirect: redirectUrl,
  ...payload,
});
```

the test fails with a relative path rather than the full URL provided which explains the incorrect SAML redirect.

```
 ● login › with username & password › should login and redirect to a provided path

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "https://api.userfront.com/v0/tenants/abcd9876/auth/saml/idp/login"
    Received: "/v0/tenants/abcd9876/auth/saml/idp/login"

    Number of calls: 1

      406 |
      407 |       // Should have redirected correctly
    > 408 |       expect(window.location.assign).toHaveBeenCalledWith(redirectUrl);
          |                                      ^
      409 |     });
      410 |
      411 |     it("password method error should respond with whatever error the server sends", async () => {

      at Object.<anonymous> (test/signon.spec.js:408:38)
```

---

If the test is "failing as expected", then we'll have to add a modification to allow absolute URLs or at least whitelist `https://api.userfront.com/v0/tenants/{id}/auth/saml/idp/login` to allow redirection after the user has logged in to complete their SAML sign-on.