### PR TITLE
83 refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.2.39",
+      "version": "0.2.40",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,14 @@ export default {
   setMode,
 
   // refresh
-  refresh,
+  refresh: (a, b, c) => {
+    try {
+      console.warn(
+        "Userfront.refresh() is deprecated and will be removed. Please use Userfront.tokens.refresh() instead."
+      );
+    } catch (error) {}
+    return refresh(a, b, c);
+  },
 
   // signon
   login,

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -3,6 +3,7 @@ import { store } from "./store.js";
 import { setUser, unsetUser } from "./user.js";
 import { refresh } from "./refresh.js";
 
+store.tokens = store.tokens || {};
 store.tokens.refresh = refresh;
 
 export function setTokenNames() {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,6 +1,9 @@
 import Cookies from "js-cookie";
 import { store } from "./store.js";
 import { setUser, unsetUser } from "./user.js";
+import { refresh } from "./refresh.js";
+
+store.tokens.refresh = refresh;
 
 export function setTokenNames() {
   store.tokens = store.tokens || {};

--- a/test/refresh.basic.spec.js
+++ b/test/refresh.basic.spec.js
@@ -40,6 +40,7 @@ describe("refresh with basic method", () => {
 
   afterEach(() => {
     resetStore(Userfront);
+    jest.resetAllMocks();
   });
 
   it("should send a refresh request and set cookies with response", async () => {
@@ -194,5 +195,26 @@ describe("refresh with basic method", () => {
     // Expect existing properties to be unchanged
     expect(Userfront.user.image).toEqual(initialUser.image);
     expect(Userfront.user.data).toEqual(initialUser.data);
+  });
+
+  it("Userfront.refresh() should log a deprecation message", async () => {
+    expect(Userfront.refresh).not.toEqual(refresh);
+
+    axios.get.mockResolvedValue({});
+
+    global.console = { warn: jest.fn() };
+    await Userfront.refresh();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "Userfront.refresh() is deprecated and will be removed. Please use Userfront.tokens.refresh() instead."
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://api.userfront.com/v0/auth/refresh",
+      {
+        headers: {
+          authorization: `Bearer ${mockRefreshToken}`,
+        },
+      }
+    );
   });
 });

--- a/test/tokens.spec.js
+++ b/test/tokens.spec.js
@@ -1,6 +1,7 @@
 import Cookies from "js-cookie";
 import Userfront from "../src/index.js";
 import { createAccessToken, createIdToken } from "./config/utils.js";
+import { refresh } from "../src/refresh.js";
 
 const tenantId = "abcd4321";
 const mockAccessToken = createAccessToken();
@@ -29,5 +30,9 @@ describe("Userfront.tokens helpers", () => {
 
   it("tokens.idTokenName should give name of ID token", () => {
     expect(Userfront.tokens.idTokenName).toEqual(`id.${tenantId}`);
+  });
+
+  it("tokens.refresh should equal the refresh method", () => {
+    expect(Userfront.tokens.refresh).toEqual(refresh);
   });
 });


### PR DESCRIPTION
Glance
Closes #83

Add `Userfront.tokens.refresh()` method
Deprecate `Userfront.refresh()` method with warning