### PR TITLE
88 bulldoze cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.2.40",
+      "version": "0.2.41",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -25,11 +25,37 @@ export function setCookie(value, options, type) {
  * @param {String} name
  */
 function removeCookie(name) {
-  Cookies.remove(name);
-  Cookies.remove(name, { secure: true, sameSite: "Lax" });
-  Cookies.remove(name, { secure: true, sameSite: "None" });
-  Cookies.remove(name, { secure: false, sameSite: "Lax" });
-  Cookies.remove(name, { secure: false, sameSite: "None" });
+  // Define all possible path and domain combinations
+  let paths, domains;
+  try {
+    const path = window.location.pathname;
+    const hostname = window.location.hostname;
+    const hostnameParts = hostname.split(".");
+    const primaryDomain = hostnameParts
+      .slice(Math.max(hostnameParts.length - 2, 0))
+      .join(".");
+    paths = [undefined, path, "/"];
+    domains = [
+      undefined,
+      hostname,
+      `.${hostname}`,
+      primaryDomain,
+      `.${primaryDomain}`,
+    ];
+  } catch (err) {
+    paths = [undefined, "/"];
+    domains = [undefined];
+  }
+
+  // Iterate over paths and domains, and remove cookies if present
+  paths.map((path) => {
+    domains.map((domain) => {
+      const options = {};
+      if (domain) options.domain = domain;
+      if (path) options.path = path;
+      Cookies.remove(name, options);
+    });
+  });
 }
 
 /**

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -31,9 +31,7 @@ function removeCookie(name) {
     const path = window.location.pathname;
     const hostname = window.location.hostname;
     const hostnameParts = hostname.split(".");
-    const primaryDomain = hostnameParts
-      .slice(Math.max(hostnameParts.length - 2, 0))
-      .join(".");
+    const primaryDomain = hostnameParts.slice(-2).join(".");
     paths = [undefined, path, "/"];
     domains = [
       undefined,

--- a/test/config/cookies-jsdom.js
+++ b/test/config/cookies-jsdom.js
@@ -1,0 +1,217 @@
+"use strict";
+/**
+ * This file is a clone of node_modules/jest-environment-jsdom/build/index.js
+ * except with a randomly generated url instead of example.com. This is useful
+ * to test cookie removal at random subdomains because jest and jsdom do not
+ * allow navigation to a different domain than the one specified in jest.config.js
+ */
+
+// Return a random alphabetic string with random dashes
+function randomString() {
+  return Math.random()
+    .toString(36)
+    .replace(/[^a-z]+/g, "-")
+    .substring(2)
+    .replace(/^-+|-+$/g, "");
+}
+
+// Return a random URL with 0-3 subdomains
+function randomUrl() {
+  let hostname = `${randomString()}.com`;
+  let numberOfSubdomains = Math.floor(Math.random() * 4);
+  while (numberOfSubdomains > 0) {
+    hostname = `${randomString()}.${hostname}`;
+    numberOfSubdomains--;
+  }
+  return `https://${hostname}`;
+}
+
+/**
+ * Everything below this line is unchanged, except the following line:
+ * url: randomUrl(),
+ */
+
+function _jsdom() {
+  const data = require("jsdom");
+
+  _jsdom = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _fakeTimers() {
+  const data = require("@jest/fake-timers");
+
+  _fakeTimers = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestMock() {
+  const data = require("jest-mock");
+
+  _jestMock = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestUtil() {
+  const data = require("jest-util");
+
+  _jestUtil = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _defineProperty(obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  } else {
+    obj[key] = value;
+  }
+  return obj;
+}
+
+class JSDOMEnvironment {
+  constructor(config, options = {}) {
+    _defineProperty(this, "dom", void 0);
+
+    _defineProperty(this, "fakeTimers", void 0);
+
+    _defineProperty(this, "fakeTimersModern", void 0);
+
+    _defineProperty(this, "global", void 0);
+
+    _defineProperty(this, "errorEventListener", void 0);
+
+    _defineProperty(this, "moduleMocker", void 0);
+
+    this.dom = new (_jsdom().JSDOM)("<!DOCTYPE html>", {
+      pretendToBeVisual: true,
+      runScripts: "dangerously",
+      url: randomUrl(),
+      virtualConsole: new (_jsdom().VirtualConsole)().sendTo(
+        options.console || console
+      ),
+      ...config.testEnvironmentOptions,
+    });
+    const global = (this.global = this.dom.window.document.defaultView);
+
+    if (!global) {
+      throw new Error("JSDOM did not return a Window object");
+    } // In the `jsdom@16`, ArrayBuffer was not added to Window, ref: https://github.com/jsdom/jsdom/commit/3a4fd6258e6b13e9cf8341ddba60a06b9b5c7b5b
+    // Install ArrayBuffer to Window to fix it. Make sure the test is passed, ref: https://github.com/facebook/jest/pull/7626
+
+    global.ArrayBuffer = ArrayBuffer; // Node's error-message stack size is limited at 10, but it's pretty useful
+    // to see more than that when a test fails.
+
+    this.global.Error.stackTraceLimit = 100;
+    (0, _jestUtil().installCommonGlobals)(global, config.globals); // Report uncaught errors.
+
+    this.errorEventListener = (event) => {
+      if (userErrorListenerCount === 0 && event.error) {
+        process.emit("uncaughtException", event.error);
+      }
+    };
+
+    global.addEventListener("error", this.errorEventListener); // However, don't report them as uncaught if the user listens to 'error' event.
+    // In that case, we assume the might have custom error handling logic.
+
+    const originalAddListener = global.addEventListener;
+    const originalRemoveListener = global.removeEventListener;
+    let userErrorListenerCount = 0;
+
+    global.addEventListener = function (...args) {
+      if (args[0] === "error") {
+        userErrorListenerCount++;
+      }
+
+      return originalAddListener.apply(this, args);
+    };
+
+    global.removeEventListener = function (...args) {
+      if (args[0] === "error") {
+        userErrorListenerCount--;
+      }
+
+      return originalRemoveListener.apply(this, args);
+    };
+
+    this.moduleMocker = new (_jestMock().ModuleMocker)(global);
+    const timerConfig = {
+      idToRef: (id) => id,
+      refToId: (ref) => ref,
+    };
+    this.fakeTimers = new (_fakeTimers().LegacyFakeTimers)({
+      config,
+      global,
+      moduleMocker: this.moduleMocker,
+      timerConfig,
+    });
+    this.fakeTimersModern = new (_fakeTimers().ModernFakeTimers)({
+      config,
+      global,
+    });
+  }
+
+  async setup() {}
+
+  async teardown() {
+    if (this.fakeTimers) {
+      this.fakeTimers.dispose();
+    }
+
+    if (this.fakeTimersModern) {
+      this.fakeTimersModern.dispose();
+    }
+
+    if (this.global) {
+      if (this.errorEventListener) {
+        this.global.removeEventListener("error", this.errorEventListener);
+      } // Dispose "document" to prevent "load" event from triggering.
+
+      Object.defineProperty(this.global, "document", {
+        value: null,
+      });
+      this.global.close();
+    }
+
+    this.errorEventListener = null; // @ts-expect-error
+
+    this.global = null;
+    this.dom = null;
+    this.fakeTimers = null;
+    this.fakeTimersModern = null;
+  }
+
+  runScript(script) {
+    if (this.dom) {
+      return script.runInContext(this.dom.getInternalVMContext());
+    }
+
+    return null;
+  }
+
+  getVmContext() {
+    if (this.dom) {
+      return this.dom.getInternalVMContext();
+    }
+
+    return null;
+  }
+}
+
+module.exports = JSDOMEnvironment;

--- a/test/cookies.spec.js
+++ b/test/cookies.spec.js
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment ./test/config/cookies-jsdom.js
+ */
+
+// The line above pulls in a custom JSDOM environment
+// that assigns a random URL instead of example.com
+
+import Cookie from "js-cookie";
+import Userfront from "../src/index.js";
+import { removeAllCookies } from "../src/cookies.js";
+
+const tenantId = "abcd4321";
+Userfront.init(tenantId);
+
+describe("removeAllCookies", () => {
+  it("should remove all possible variants (based on path and domain) of all access, ID, and refresh cookies", async () => {
+    // Navigate to custom path
+    window.history.pushState({}, "", "/custom/path");
+
+    // Define all domains and paths
+    const domains = [undefined, location.hostname, `.${location.hostname}`];
+    const paths = [undefined, location.pathname, "/"];
+    const names = [
+      `access.${tenantId}`,
+      `id.${tenantId}`,
+      `refresh.${tenantId}`,
+    ];
+
+    // Set up tests and make assertions for all domains and paths
+    domains.map((domain) => {
+      paths.map((path) => {
+        const options = {};
+        if (domain) options.domain = domain;
+        if (path) options.path = path;
+
+        // Cookies should not exist before the test
+        names.map((name) => {
+          expect(Cookie.get(name, options)).toBeFalsy();
+        });
+
+        // Add the cookies directly
+        names.map((name) => {
+          Cookie.set(
+            name,
+            `{\n\tname: ${name},\n\tdomain: ${domain},\n\tpath: ${path}\n}`,
+            options
+          );
+        });
+
+        // Call removeAllCookies
+        removeAllCookies();
+
+        // Cookies should all have been removed
+        names.map((name) => {
+          expect(Cookie.get(name, options)).toBeFalsy();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Normal
Closes #88 

This PR tests that all JWT cookies are cleared with all possible permutations of `path` and `domain` options. This way if an end user logs in at e.g. `example.com` and is redirected to `subdomain.example.com`, they can still log out from the latter domain.

Testing this was a little bit tricky since JSDOM (what Jest uses) doesn't allow for navigating the URL within a test, only the path.