### PR TITLE
Bump patch version with proper build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.2.41",
+      "version": "0.2.42",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",


### PR DESCRIPTION
Glance

`0.3.0` had an error somewhere in the build step, so this is rebuilt correctly for deploy.