### PR TITLE
feat: add origin header opt

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,13 +42,13 @@ function init(tenantId, opts = {}) {
 
   if (opts.domain) {
     store.domain = opts.domain;
+    const url = `https://${store.domain}`;
     axios.defaults.headers.common[
       "x-application-id"
-    ] = `https://${store.domain}`;
-  }
-
-  if (opts.originHeader) {
-    axios.defaults.headers.common.origin = opts.originHeader
+    ] = url
+    axios.defaults.headers.common[
+      "x-origin"
+    ] = url
   }
 
   setTokenNames();

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,10 @@ function init(tenantId, opts = {}) {
     ] = `https://${store.domain}`;
   }
 
+  if (opts.originHeader) {
+    axios.defaults.headers.common.origin = opts.originHeader
+  }
+
   setTokenNames();
   // setIframe(); // TODO re-enable when iframe is needed
   setTokensFromCookies();

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -66,7 +66,7 @@ describe("init() method with domain option", () => {
       url
     );
     expect(axios.get).toHaveBeenCalledWith(
-      `https://api.userfront.com/v0/tenants/${tenantId}/mode`,
+      `https://api.userfront.com/v0/tenants/${tenantId}/mode`
     );
     expect(store.mode).toEqual("live");
   });
@@ -111,7 +111,7 @@ describe("init() method with domain option", () => {
     const url = `https://${domain}`
 
     expect(axios.defaults.headers.common["x-application-id"]).toEqual(
-      `https://${domain}`
+      url
     );
     expect(axios.defaults.headers.common["x-origin"]).toEqual(
       url

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -45,7 +45,7 @@ describe("init() method with domain option", () => {
     jest.resetAllMocks();
   });
 
-  it("should include the x-application-id and x-origin header for mode", async () => {
+  it("should include the x-application-id and x-origin headers for mode", async () => {
     store.mode = "test";
     Userfront.init(tenantId, { domain });
 
@@ -71,7 +71,7 @@ describe("init() method with domain option", () => {
     expect(store.mode).toEqual("live");
   });
 
-  it("should include the x-application-id header for signup", async () => {
+  it("should include the x-application-id and x-origin headers for signup", async () => {
     Userfront.init(tenantId, { domain });
 
     const email = "user@example.com";
@@ -100,7 +100,7 @@ describe("init() method with domain option", () => {
     );
   });
 
-  it("should include the x-application-id header for login", async () => {
+  it("should include the x-application-id and x-origin headers for login", async () => {
     Userfront.init(tenantId, { domain });
 
     const email = "user@example.com";
@@ -116,6 +116,7 @@ describe("init() method with domain option", () => {
     expect(axios.defaults.headers.common["x-origin"]).toEqual(
       url
     );
+
     expect(axios.post).toHaveBeenCalledWith(
       "https://api.userfront.com/v0/auth/basic",
       {
@@ -126,7 +127,7 @@ describe("init() method with domain option", () => {
     );
   });
 
-  it("should include the x-application-id header for logout", async () => {
+  it("should include the x-application-id and x-origin headers for logout", async () => {
     Userfront.init(tenantId, { domain });
 
     axios.get.mockResolvedValue({

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -45,7 +45,7 @@ describe("init() method with domain option", () => {
     jest.resetAllMocks();
   });
 
-  it("should include the x-application-id header for mode", async () => {
+  it("should include the x-application-id and x-origin header for mode", async () => {
     store.mode = "test";
     Userfront.init(tenantId, { domain });
 
@@ -57,11 +57,16 @@ describe("init() method with domain option", () => {
     });
     await setMode();
 
+    const url = `https://${domain}`
+
     expect(axios.defaults.headers.common["x-application-id"]).toEqual(
-      `https://${domain}`
+      url
+    );
+    expect(axios.defaults.headers.common["x-origin"]).toEqual(
+      url
     );
     expect(axios.get).toHaveBeenCalledWith(
-      `https://api.userfront.com/v0/tenants/${tenantId}/mode`
+      `https://api.userfront.com/v0/tenants/${tenantId}/mode`,
     );
     expect(store.mode).toEqual("live");
   });
@@ -74,8 +79,13 @@ describe("init() method with domain option", () => {
 
     await Userfront.signup({ method: "password", email, password });
 
+    const url = `https://${domain}`
+
     expect(axios.defaults.headers.common["x-application-id"]).toEqual(
-      `https://${domain}`
+      url
+    );
+    expect(axios.defaults.headers.common["x-origin"]).toEqual(
+      url
     );
     expect(axios.post).toHaveBeenCalledWith(
       "https://api.userfront.com/v0/auth/create",
@@ -86,7 +96,7 @@ describe("init() method with domain option", () => {
         name: undefined,
         data: undefined,
         tenantId,
-      }
+      },
     );
   });
 
@@ -98,8 +108,13 @@ describe("init() method with domain option", () => {
 
     await Userfront.login({ method: "password", email, password });
 
+    const url = `https://${domain}`
+
     expect(axios.defaults.headers.common["x-application-id"]).toEqual(
       `https://${domain}`
+    );
+    expect(axios.defaults.headers.common["x-origin"]).toEqual(
+      url
     );
     expect(axios.post).toHaveBeenCalledWith(
       "https://api.userfront.com/v0/auth/basic",
@@ -125,8 +140,13 @@ describe("init() method with domain option", () => {
 
     await Userfront.logout();
 
+    const url = `https://${domain}`
+
     expect(axios.defaults.headers.common["x-application-id"]).toEqual(
-      `https://${domain}`
+      url
+    );
+    expect(axios.defaults.headers.common["x-origin"]).toEqual(
+      url
     );
     expect(axios.get).toHaveBeenCalledWith(
       "https://api.userfront.com/v0/auth/logout",


### PR DESCRIPTION
# Description

The Userfront API allows you to mimic "live mode" requests by [setting the `origin` header for the request to one of your "Live domains"](https://userfront.com/guide/test-mode.html#mimick-live-mode-for-api-requests). This functionality is currently not supported by this library but would be very useful for testing applications which utilize password-less login and password reset flows.

This adds the ability to pass in a url to use as the `origin` header value for all network requests made by the lib.

Usage in a consuming application would look something like this:

```js
Userfront.init('ab12c3d4', {
  originHeader: process.env.NODE_ENV === 'development'
    ? 'https://userfront-live-domain.com'
    : null
})
```
