### PR TITLE
Rename security code to verification code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/mfa.js
+++ b/src/mfa.js
@@ -18,17 +18,17 @@ export async function sendSms({ type, to, firstFactorCode } = {}) {
   }
 
   switch (type) {
-    case "securityCode":
+    case "verificationCode":
       if (!to || !firstFactorCode) {
         throw new Error(
-          'Userfront.sendSms type "securityCode" requires "to" and "firstFactorCode".'
+          'Userfront.sendSms type "verificationCode" requires "to" and "firstFactorCode".'
         );
       }
 
-      return sendSecurityCode({
+      return sendVerificationCode({
         firstFactorCode,
         to,
-        strategy: "securityCode",
+        strategy: "verificationCode",
         channel: "sms",
       });
     default:
@@ -37,21 +37,21 @@ export async function sendSms({ type, to, firstFactorCode } = {}) {
 }
 
 /**
- * Send an MFA security code
+ * Send an MFA verification code
  * @param {String} firstFactorCode Identifier obtained from login() response
  * @param {String} strategy Type of MFA strategy
- * @param {String} channel Method of sending the security code
+ * @param {String} channel Method of sending the verification code
  * @param {String} to Phone number in E.164 format
  * @returns {Object}
  */
-export async function sendSecurityCode({
+export async function sendVerificationCode({
   firstFactorCode,
   strategy,
   channel,
   to,
 } = {}) {
   if (!firstFactorCode || !strategy || !channel || !to) {
-    throw new Error("Userfront.sendSecurityCode missing parameters.");
+    throw new Error("Userfront.sendVerificationCode missing parameters.");
   }
 
   try {
@@ -70,26 +70,26 @@ export async function sendSecurityCode({
 }
 
 /**
- * Log in using firstFactorCode and MFA security code
+ * Log in using firstFactorCode and MFA verification code
  * @param {String} firstFactorCode Identifier obtained from login() response
- * @param {String} securityCode Code provided by the user
+ * @param {String} verificationCode Code provided by the user
  * @param {String|Boolean} redirect Redirect to given path unless specified as `false`
  * @returns {Object}
  */
-export async function loginWithSecurityCode({
+export async function loginWithVerificationCode({
   firstFactorCode,
-  securityCode,
+  verificationCode,
   redirect,
 } = {}) {
-  if (!firstFactorCode || !securityCode) {
-    throw new Error("Userfront.loginWithSecurityCode missing parameters.");
+  if (!firstFactorCode || !verificationCode) {
+    throw new Error("Userfront.loginWithVerificationCode missing parameters.");
   }
 
   try {
     const { data } = await axios.put(`${store.baseUrl}auth/mfa`, {
       tenantId: store.tenantId,
       firstFactorCode,
-      securityCode,
+      verificationCode,
     });
 
     setCookiesAndTokens(data.tokens);

--- a/src/signon.js
+++ b/src/signon.js
@@ -4,7 +4,7 @@ import { store } from "./store.js";
 import { getQueryAttr, redirectToPath } from "./url.js";
 import { exchange } from "./refresh.js";
 import { throwFormattedError } from "./utils.js";
-import { loginWithSecurityCode } from "./mfa.js";
+import { loginWithVerificationCode } from "./mfa.js";
 
 /**
  * This file has methods for signing up and logging in
@@ -134,7 +134,7 @@ export async function login({
   token,
   uuid,
   firstFactorCode,
-  securityCode,
+  verificationCode,
   redirect,
 } = {}) {
   if (!method) {
@@ -161,7 +161,11 @@ export async function login({
     case "link":
       return loginWithLink({ token, uuid, redirect });
     case "mfa":
-      return loginWithSecurityCode({ firstFactorCode, securityCode, redirect });
+      return loginWithVerificationCode({
+        firstFactorCode,
+        verificationCode,
+        redirect,
+      });
     case "saml":
       return completeSamlLogin();
     default:

--- a/test/mfa.spec.js
+++ b/test/mfa.spec.js
@@ -8,9 +8,9 @@ import {
   idTokenUserDefaults,
 } from "./config/utils.js";
 import {
-  sendSecurityCode,
+  sendVerificationCode,
   sendSms,
-  loginWithSecurityCode,
+  loginWithVerificationCode,
 } from "../src/mfa.js";
 import { exchange } from "../src/refresh.js";
 
@@ -25,7 +25,7 @@ jest.mock("axios");
 const tenantId = "abcd9876";
 const firstFactorCode = "204a8def-651c-4ab2-9ca0-1e3fca9e280a";
 const phoneNumber = "+15558675309";
-const securityCode = "123456";
+const verificationCode = "123456";
 
 // Using `window.location.assign` rather than `window.location.href =` because
 // JSDOM throws an error "Error: Not implemented: navigation (except hash changes)"
@@ -64,22 +64,22 @@ const mockLoginResponse = {
   },
 };
 
-describe("sendSecurityCode", () => {
+describe("sendVerificationCode", () => {
   beforeEach(() => {
     Userfront.init(tenantId);
   });
 
   it(`should throw if missing parameters`, async () => {
     const missingParamsError = new Error(
-      "Userfront.sendSecurityCode missing parameters."
+      "Userfront.sendVerificationCode missing parameters."
     );
 
-    expect(sendSecurityCode()).rejects.toEqual(missingParamsError);
+    expect(sendVerificationCode()).rejects.toEqual(missingParamsError);
 
     // Missing firstFactorCode
     expect(
-      sendSecurityCode({
-        strategy: "securityCode",
+      sendVerificationCode({
+        strategy: "verificationCode",
         channel: "sms",
         to: phoneNumber,
       })
@@ -87,7 +87,7 @@ describe("sendSecurityCode", () => {
 
     // Missing strategy
     expect(
-      sendSecurityCode({
+      sendVerificationCode({
         firstFactorCode,
         channel: "sms",
         to: phoneNumber,
@@ -96,18 +96,18 @@ describe("sendSecurityCode", () => {
 
     // Missing channel
     expect(
-      sendSecurityCode({
+      sendVerificationCode({
         firstFactorCode,
-        strategy: "securityCode",
+        strategy: "verificationCode",
         to: phoneNumber,
       })
     ).rejects.toEqual(missingParamsError);
 
     // Missing to
     expect(
-      sendSecurityCode({
+      sendVerificationCode({
         firstFactorCode,
-        strategy: "securityCode",
+        strategy: "verificationCode",
         channel: "sms",
       })
     ).rejects.toEqual(missingParamsError);
@@ -121,11 +121,11 @@ describe("sendSecurityCode", () => {
     axios.post.mockImplementationOnce(() => mockSendSmsResponse);
     const payload = {
       firstFactorCode,
-      strategy: "securityCode",
+      strategy: "verificationCode",
       channel: "sms",
       to: phoneNumber,
     };
-    const res = await sendSecurityCode(payload);
+    const res = await sendVerificationCode(payload);
 
     // Should have sent the proper API request
     expect(axios.post).toHaveBeenCalledWith(
@@ -157,16 +157,16 @@ describe("sendSms", () => {
     );
   });
 
-  describe("type: securityCode", () => {
+  describe("type: verificationCode", () => {
     it(`should throw if missing parameters`, async () => {
       const missingParamsError = new Error(
-        'Userfront.sendSms type "securityCode" requires "to" and "firstFactorCode".'
+        'Userfront.sendSms type "verificationCode" requires "to" and "firstFactorCode".'
       );
 
       // Missing firstFactorCode
       expect(
         sendSms({
-          type: "securityCode",
+          type: "verificationCode",
           to: phoneNumber,
         })
       ).rejects.toEqual(missingParamsError);
@@ -174,7 +174,7 @@ describe("sendSms", () => {
       // Missing to
       expect(
         sendSms({
-          type: "securityCode",
+          type: "verificationCode",
           firstFactorCode,
         })
       ).rejects.toEqual(missingParamsError);
@@ -191,7 +191,7 @@ describe("sendSms", () => {
         firstFactorCode,
       };
       const res = await sendSms({
-        type: "securityCode",
+        type: "verificationCode",
         ...payload,
       });
 
@@ -200,7 +200,7 @@ describe("sendSms", () => {
         `https://api.userfront.com/v0/auth/mfa`,
         {
           tenantId,
-          strategy: "securityCode",
+          strategy: "verificationCode",
           channel: "sms",
           ...payload,
         }
@@ -213,7 +213,7 @@ describe("sendSms", () => {
   });
 });
 
-describe("loginWithSecurityCode", () => {
+describe("loginWithVerificationCode", () => {
   beforeEach(() => {
     Userfront.init(tenantId);
   });
@@ -224,21 +224,21 @@ describe("loginWithSecurityCode", () => {
 
   it(`should throw if missing parameters`, async () => {
     const missingParamsError = new Error(
-      "Userfront.loginWithSecurityCode missing parameters."
+      "Userfront.loginWithVerificationCode missing parameters."
     );
 
-    expect(loginWithSecurityCode()).rejects.toEqual(missingParamsError);
+    expect(loginWithVerificationCode()).rejects.toEqual(missingParamsError);
 
     // Missing firstFactorCode
     expect(
-      loginWithSecurityCode({
-        securityCode,
+      loginWithVerificationCode({
+        verificationCode,
       })
     ).rejects.toEqual(missingParamsError);
 
-    // Missing securityCode
+    // Missing verificationCode
     expect(
-      loginWithSecurityCode({
+      loginWithVerificationCode({
         firstFactorCode,
       })
     ).rejects.toEqual(missingParamsError);
@@ -253,9 +253,9 @@ describe("loginWithSecurityCode", () => {
     axios.put.mockImplementationOnce(() => mockLoginResponse);
     const payload = {
       firstFactorCode,
-      securityCode,
+      verificationCode,
     };
-    const res = await loginWithSecurityCode(payload);
+    const res = await loginWithVerificationCode(payload);
 
     // Should have sent the proper API request
     expect(axios.put).toHaveBeenCalledWith(
@@ -291,9 +291,9 @@ describe("loginWithSecurityCode", () => {
     axios.put.mockImplementationOnce(() => mockLoginResponse);
     const payload = {
       firstFactorCode,
-      securityCode,
+      verificationCode,
     };
-    const res = await loginWithSecurityCode({
+    const res = await loginWithVerificationCode({
       ...payload,
       redirect,
     });
@@ -321,9 +321,9 @@ describe("loginWithSecurityCode", () => {
     axios.put.mockImplementationOnce(() => mockLoginResponse);
     const payload = {
       firstFactorCode,
-      securityCode,
+      verificationCode,
     };
-    const res = await loginWithSecurityCode({
+    const res = await loginWithVerificationCode({
       ...payload,
       redirect: false,
     });

--- a/test/signon.spec.js
+++ b/test/signon.spec.js
@@ -27,7 +27,7 @@ jest.mock("axios");
 const tenantId = "abcd9876";
 const customBaseUrl = "https://custom.example.com/api/v1/";
 const firstFactorCode = "204a8def-651c-4ab2-9ca0-1e3fca9e280a";
-const securityCode = "123456";
+const verificationCode = "123456";
 
 // Using `window.location.assign` rather than `window.location.href =` because
 // JSDOM throws an error "Error: Not implemented: navigation (except hash changes)"
@@ -537,7 +537,7 @@ describe("login", () => {
       const mockMfaOptionsResponse = {
         data: {
           mode: "live",
-          allowedStrategies: ["securityCode"],
+          allowedStrategies: ["verificationCode"],
           allowedChannels: ["sms"],
           firstFactorCode: "204a8def-651c-4ab2-9ca0-1e3fca9e280a",
         },
@@ -742,14 +742,14 @@ describe("login", () => {
     });
   });
 
-  describe("with MFA security code", () => {
+  describe("with MFA verification code", () => {
     it("should respond with tokens", async () => {
       // Mock the API response
       axios.put.mockImplementationOnce(() => mockResponse);
 
       const payload = {
         firstFactorCode,
-        securityCode,
+        verificationCode,
       };
 
       const res = await login({
@@ -778,7 +778,7 @@ describe("login", () => {
       await login({
         method: "mfa",
         firstFactorCode,
-        securityCode,
+        verificationCode,
         redirect: "/custom",
       });
 
@@ -805,7 +805,7 @@ describe("login", () => {
         login({
           method: "mfa",
           firstFactorCode,
-          securityCode,
+          verificationCode,
         })
       ).rejects.toEqual(new Error(mockResponseErr.response.data.message));
     });
@@ -1078,7 +1078,7 @@ describe("loginWithLink", () => {
     const mockMfaOptionsResponse = {
       data: {
         mode: "live",
-        allowedStrategies: ["securityCode"],
+        allowedStrategies: ["verificationCode"],
         allowedChannels: ["sms"],
         firstFactorCode: "204a8def-651c-4ab2-9ca0-1e3fca9e280a",
       },


### PR DESCRIPTION
Glance
Closes #98 

I did a find/replace for all permutations of "security code" and replaced with the equivalent "verification code".