### PR TITLE
fix: password-less signup response interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Userfront.user;
 /** =>
  * {
  *    email: "jane@example.com",
+ *    phoneNumber: "+15558675309",
  *    name: "Jane Example",
  *    image: "https://res.cloudinary.com/component/image/upload/avatars/avatar-plain-9.png",
  *    data: {},

--- a/src/user.js
+++ b/src/user.js
@@ -15,6 +15,7 @@ export function setUser() {
   // Set basic user information properties from ID token
   const propsToDefine = [
     "email",
+    "phoneNumber",
     "username",
     "name",
     "image",

--- a/test/config/utils.js
+++ b/test/config/utils.js
@@ -15,6 +15,7 @@ export const defaultIdTokenProperties = [
   "isConfirmed",
   "name",
   "email",
+  "phoneNumber",
   "username",
   "image",
   "data",

--- a/ts/index.d.ts
+++ b/ts/index.d.ts
@@ -7,6 +7,7 @@ export declare function addInitCallback(callback: Function): void;
 // user
 interface User {
   email?: string;
+  phoneNumber?: string;
   name?: string;
   image?: string;
   data?: object;
@@ -56,19 +57,24 @@ interface SignupResponse {
   mode: string;
   // User attributes
   userId?: number;
-  uuid?: string;
+  tenantId?: string;
+  userUuid?: string;
   username?: string;
   email?: string;
+  phoneNumber?: string;
   name?: string;
   image?: string;
   locked?: boolean;
   data?: object;
-  authorization?: object;
   isConfirmed?: boolean;
   lastActiveAt?: string;
-  updatedAt?: string;
+  lastMessagedAt?: string;
+  confirmedAt?: string;
   createdAt?: string;
+  updatedAt?: string;
   tenant?: object;
+  authorization?: object;
+  uuid?: string; // deprecated
   // Response
   tokens?: TokensObject;
   redirectTo?: string;
@@ -84,6 +90,8 @@ interface LoginResponse {
   redirectTo?: string;
   sessionId?: string;
   nonce?: string;
+  message?: string;
+  result?: LinkResult;
 }
 
 interface LogoutResponse {
@@ -92,10 +100,11 @@ interface LogoutResponse {
 }
 
 interface LinkResult {
-  to?: string;
+  email?: string;
   submittedAt?: string;
   messageId?: string;
   url?: string;
+  to?: string; // deprecated
 }
 
 interface LinkResponse {
@@ -109,6 +118,7 @@ export declare function signup({
   email,
   username,
   name,
+  data,
   password,
   redirect,
 }: {
@@ -116,6 +126,7 @@ export declare function signup({
   email?: string;
   username?: string;
   name?: string;
+  data?: object;
   password?: string;
   redirect?: string | boolean;
 }): Promise<SignupResponse>;

--- a/ts/index.d.ts
+++ b/ts/index.d.ts
@@ -74,6 +74,8 @@ interface SignupResponse {
   redirectTo?: string;
   sessionId?: string;
   nonce?: string;
+  message?: string;
+  result?: LinkResult;
 }
 
 interface LoginResponse {


### PR DESCRIPTION
# Summary

Adds some missing fields on the `SignupResponse` interface because when calling `Userfront.signup({ method: 'passwordless' ... })`, some fields were missing which makes the TS compiler complain.

As an example, calling this:

```js
const signupResp = await Userfront.signup({
  method: 'passwordless',
  email: `tom.ford@gucci.com',
  name: 'thomas ford',
  redirect: false,
})
```

returns an object like this:

```
{
  message: 'OK',
  result: {
    url: '/?uuid=ed03123c-b476-1234-ab0c-ac3f93952920&token=68373948-aec3-489d-8dh3-94bddeb05635&type=login'
  }
}
```