### PR TITLE
feat: add updateCurrentUserPassword

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:beta": "npm version prerelease --preid=beta && microbundle",
     "pub:beta": "npm publish --tag beta",
     "reinstall": "rm -rf node_modules && rm package-lock.json && npm install",
-    "ts:copy": "cp ts/index.d.ts build/userfront-core.d.ts; cp ts/index.d.ts build/userfront-core.modern.d.ts; cp ts/index.d.ts build/userfront-core.module.d.ts; cp ts/index.d.ts build/userfront-core.umd.d.ts"
+    "ts:copy": "cp ts/index.d.ts build/userfront-core.d.ts; cp ts/index.d.ts build/userfront-core.modern.d.ts; cp ts/index.d.ts build/userfront-core.module.d.ts; cp ts/index.d.ts build/userfront-core.umd.d.ts",
+    "watch": "microbundle watch --external none && npm run ts:copy"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { sendSms } from "./mfa.js";
 import {
   login,
   resetPassword,
+  updateCurrentUserPassword,
   sendLoginLink,
   sendResetLink,
   signup,
@@ -138,6 +139,7 @@ export default {
   // signon
   login,
   resetPassword,
+  updateCurrentUserPassword,
   sendLoginLink,
   sendResetLink,
   signup,

--- a/src/signon.js
+++ b/src/signon.js
@@ -389,3 +389,37 @@ export async function resetPassword({ uuid, token, password, redirect }) {
     throwFormattedError(error);
   }
 }
+
+export async function updateCurrentUserPassword({ password, existingPassword }) {
+  try {
+    if (!store.tokens.accessToken) {
+      throw new Error(
+        "No access token found. You must be authenticated to use this function."
+      )
+    }
+    /**
+     * @todo handle the case theat existing password is not passed and it causes an error
+     */
+    const res = await axios.put(
+      `${store.baseUrl}auth/basic`,
+      {
+        tenantId: store.tenantId,
+        password,
+        existingPassword,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${store.tokens.accessToken}`,
+        },
+      },
+    )
+
+    const { data } = res
+
+    console.log(res, data, res.status)
+
+    return data
+  } catch (error) {
+    throwFormattedError(error)
+  }
+}

--- a/src/signon.js
+++ b/src/signon.js
@@ -397,10 +397,8 @@ export async function updateCurrentUserPassword({ password, existingPassword }) 
         "No access token found. You must be authenticated to use this function."
       )
     }
-    /**
-     * @todo handle the case theat existing password is not passed and it causes an error
-     */
-    const res = await axios.put(
+    
+    const { data } = await axios.put(
       `${store.baseUrl}auth/basic`,
       {
         tenantId: store.tenantId,
@@ -413,10 +411,6 @@ export async function updateCurrentUserPassword({ password, existingPassword }) 
         },
       },
     )
-
-    const { data } = res
-
-    console.log(res, data, res.status)
 
     return data
   } catch (error) {

--- a/ts/index.d.ts
+++ b/ts/index.d.ts
@@ -112,6 +112,10 @@ interface LinkResponse {
   result?: LinkResult;
 }
 
+interface UpdateCurrentUserPasswordResult {
+  message: string;
+}
+
 // signup()
 export declare function signup({
   method,
@@ -178,6 +182,12 @@ export declare function resetPassword({
   uuid?: string;
   redirect?: string | boolean;
 }): Promise<LoginResponse>;
+
+// updateCurrentUserPassword()
+export declare function updateCurrentUserPassword({
+  password: string,
+  existingPassword?: string,
+})
 
 // sendLoginLink()
 export declare function sendLoginLink(email: string): Promise<LinkResponse>;


### PR DESCRIPTION
# Summary

In #103 we are discussing options for adding a method for the Userfront `PUT /auth/basic` endpoint to this library. This is currently a draft PR implementing one of the two discussed options.

If we do decide to go this route (adding the new method) I'll add tests 🙂