### PR TITLE
110 send verification code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,9 @@ import { redirectIfLoggedIn } from "./url.js";
 import { sendSms } from "./mfa.js";
 import { signup } from "./signup.js";
 import { login } from "./login.js";
-import { sendLoginLink } from "./link.js";
 import { updatePassword, resetPassword, sendResetLink } from "./password.js";
+import { sendLoginLink } from "./link.js";
+import { sendVerificationCode } from "./verificationCode";
 import { logout } from "./logout.js";
 import { mode, setMode, setModeSync } from "./mode.js";
 // import { setIframe } from "./iframe.js";
@@ -134,6 +135,7 @@ export default {
   updatePassword,
   sendLoginLink,
   sendResetLink,
+  sendVerificationCode,
   signup,
 
   // store

--- a/src/mfa.js
+++ b/src/mfa.js
@@ -25,7 +25,7 @@ export async function sendSms({ type, phoneNumber, firstFactorCode } = {}) {
         );
       }
 
-      return sendVerificationCode({
+      return sendMfaCode({
         firstFactorCode,
         phoneNumber,
         strategy: "verificationCode",
@@ -44,14 +44,14 @@ export async function sendSms({ type, phoneNumber, firstFactorCode } = {}) {
  * @param {String} phoneNumber Phone number in E.164 format
  * @returns {Object}
  */
-export async function sendVerificationCode({
+export async function sendMfaCode({
   firstFactorCode,
   strategy,
   channel,
   phoneNumber,
 } = {}) {
   if (!firstFactorCode || !strategy || !channel || !phoneNumber) {
-    throw new Error("Userfront.sendVerificationCode missing parameters.");
+    throw new Error("Userfront.sendMfaCode missing parameters.");
   }
 
   try {

--- a/src/signup.js
+++ b/src/signup.js
@@ -56,7 +56,7 @@ export async function signup({
         phoneNumber,
         name,
         username,
-        userData: data,
+        data,
       });
     default:
       throw new Error(

--- a/src/verificationCode.js
+++ b/src/verificationCode.js
@@ -37,7 +37,7 @@ export async function sendVerificationCode({
   email,
   name,
   username,
-  userData,
+  data,
 }) {
   try {
     enforceChannel({
@@ -46,16 +46,16 @@ export async function sendVerificationCode({
       email,
     });
 
-    const { data } = await post(`/auth/code`, {
+    const { data: res } = await post(`/auth/code`, {
       channel,
       email,
       phoneNumber,
       name,
       username,
-      data: userData,
+      data,
       tenantId: store.tenantId,
     });
-    return data;
+    return res;
   } catch (error) {
     throwFormattedError(error);
   }

--- a/test/mfa.spec.js
+++ b/test/mfa.spec.js
@@ -7,7 +7,7 @@ import {
   idTokenUserDefaults,
   mockWindow,
 } from "./config/utils.js";
-import { sendVerificationCode, sendSms, loginWithMfa } from "../src/mfa.js";
+import { sendMfaCode, sendSms, loginWithMfa } from "../src/mfa.js";
 import { exchange } from "../src/refresh.js";
 
 jest.mock("../src/api.js");
@@ -49,21 +49,21 @@ const mockLoginResponse = {
   },
 };
 
-describe("sendVerificationCode", () => {
+describe("sendMfaCode", () => {
   beforeEach(() => {
     Userfront.init(tenantId);
   });
 
   it(`should throw if missing parameters`, async () => {
     const missingParamsError = new Error(
-      "Userfront.sendVerificationCode missing parameters."
+      "Userfront.sendMfaCode missing parameters."
     );
 
-    expect(sendVerificationCode()).rejects.toEqual(missingParamsError);
+    expect(sendMfaCode()).rejects.toEqual(missingParamsError);
 
     // Missing firstFactorCode
     expect(
-      sendVerificationCode({
+      sendMfaCode({
         strategy: "verificationCode",
         channel: "sms",
         phoneNumber,
@@ -72,7 +72,7 @@ describe("sendVerificationCode", () => {
 
     // Missing strategy
     expect(
-      sendVerificationCode({
+      sendMfaCode({
         firstFactorCode,
         channel: "sms",
         phoneNumber,
@@ -81,7 +81,7 @@ describe("sendVerificationCode", () => {
 
     // Missing channel
     expect(
-      sendVerificationCode({
+      sendMfaCode({
         firstFactorCode,
         strategy: "verificationCode",
         phoneNumber,
@@ -90,7 +90,7 @@ describe("sendVerificationCode", () => {
 
     // Missing to
     expect(
-      sendVerificationCode({
+      sendMfaCode({
         firstFactorCode,
         strategy: "verificationCode",
         channel: "sms",
@@ -110,7 +110,7 @@ describe("sendVerificationCode", () => {
       channel: "sms",
       phoneNumber,
     };
-    const data = await sendVerificationCode(payload);
+    const data = await sendMfaCode(payload);
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(`/auth/mfa`, {

--- a/test/signup.spec.js
+++ b/test/signup.spec.js
@@ -137,8 +137,6 @@ describe("signup()", () => {
         Userfront.signup({ method: "verificationCode", ...combo });
 
         // Assert that sendVerificationCode was called
-        combo.userData = combo.data;
-        delete combo.data;
         expect(sendVerificationCode).toHaveBeenCalledWith(combo);
       });
     });

--- a/test/singleton.spec.js
+++ b/test/singleton.spec.js
@@ -1,0 +1,47 @@
+import Userfront from "../src/index.js";
+
+describe(`Userfront object`, () => {
+  beforeAll(() => {
+    Userfront.init("demo1234");
+  });
+  describe("should export proper methods on the singleton", () => {
+    const methods = [
+      // index
+      "addInitCallback",
+      "init",
+      "registerUrlChangedEventListener",
+      //logout
+      "logout",
+      // mode
+      "setMode",
+      // refresh
+      "refresh",
+      // signon
+      "login",
+      "resetPassword",
+      "updatePassword",
+      "sendLoginLink",
+      "sendResetLink",
+      "sendVerificationCode",
+      "signup",
+      // url
+      "redirectIfLoggedIn",
+    ];
+    methods.forEach((method) => {
+      it(`should have Userfront.${method}()`, () => {
+        expect(Userfront[method]).not.toBeUndefined();
+        expect(typeof Userfront[method]).toEqual("function");
+      });
+    });
+  });
+
+  describe("should export proper methods on the user object", () => {
+    const methods = ["update", "updatePassword", "hasRole", "getTotp"];
+    methods.forEach((method) => {
+      it(`should have Userfront.user.${method}()`, () => {
+        expect(Userfront.user[method]).not.toBeUndefined();
+        expect(typeof Userfront.user[method]).toEqual("function");
+      });
+    });
+  });
+});

--- a/test/verificationCode.spec.js
+++ b/test/verificationCode.spec.js
@@ -42,25 +42,20 @@ describe("sendVerificationCode()", () => {
       email: "user@example.com",
       username: "new-by-sms",
       name: "New User",
-      userData: { attr: "custom-data" },
+      data: { attr: "custom-data" },
     };
 
     // Call sendVerificationCode()
-    const data = await sendVerificationCode(payload);
+    const res = await sendVerificationCode(payload);
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(`/auth/code`, {
-      channel: payload.channel,
-      phoneNumber: payload.phoneNumber,
-      email: payload.email,
-      username: payload.username,
-      name: payload.name,
-      data: payload.userData,
       tenantId,
+      ...payload,
     });
 
     // Should have returned the proper value
-    expect(data).toEqual(mockResponse.data);
+    expect(res).toEqual(mockResponse.data);
   });
 
   it(`email send should respond with API response information`, async () => {

--- a/ts/index.d.ts
+++ b/ts/index.d.ts
@@ -20,7 +20,10 @@ interface User {
   tenantId?: string;
   userId?: number;
   userUuid?: string;
+  // methods
   update?: Function;
+  updatePassword?: Function;
+  getTotp?: Function;
   hasRole?: Function;
 }
 export declare const user: User;
@@ -114,6 +117,20 @@ interface LinkResult {
 interface LinkResponse {
   message: string;
   result?: LinkResult;
+}
+
+interface VerificationCodeResult {
+  channel?: string;
+  phoneNumber?: string;
+  email?: string;
+  submittedAt?: string;
+  messageId?: string;
+  verificationCode?: string;
+}
+
+interface VerificationCodeResponse {
+  message: string;
+  result?: VerificationCodeResult;
 }
 
 // signup()
@@ -233,3 +250,20 @@ export declare function sendLoginLink(email: string): Promise<LinkResponse>;
 
 // sendResetLink()
 export declare function sendResetLink(email: string): Promise<LinkResponse>;
+
+// sendVerificationCode()
+export declare function sendVerificationCode({
+  channel,
+  phoneNumber,
+  email,
+  name,
+  username,
+  data,
+}: {
+  channel: "sms" | "email";
+  phoneNumber?: string;
+  email?: string;
+  name?: string;
+  username?: string;
+  data?: object;
+}): Promise<VerificationCodeResponse>;


### PR DESCRIPTION
Normal
Closes #110 

- Adds `sendVerificationCode()` method to the `Userfront` object
- Rename MFA `sendVerificationCode` to `sendMfaCode` for now
- Adds tests so that method exports are checked too
- Adds TS definition