### PR TITLE
118 - Add MFA handling for all auth methods

### DIFF
--- a/src/authentication.js
+++ b/src/authentication.js
@@ -28,19 +28,12 @@ export function setFirstFactors(authentication) {
   if (
     !authentication ||
     typeof authentication !== "object" ||
-    !authentication.firstFactors
+    !Array.isArray(authentication.firstFactors)
   ) {
     console.warn("setFirstFactors: invalid factors passed.");
     return;
   }
-  try {
-    authenticationData.firstFactors = authentication.firstFactors;
-    return;
-  } catch (err) {
-    console.warn(
-      `setFirstFactors: error when building factors list - ${err.message}`
-    );
-  }
+  authenticationData.firstFactors = authentication.firstFactors;
 }
 
 /**

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -1,29 +1,45 @@
 import { store } from "./store.js";
-import { get } from "./api.js";
 
 // Data specific to the MFA service
-export const mfaData = {
+export const authenticationData = {
   firstFactors: [],
   secondFactors: [],
-  firstFactorToken: null
-}
+  firstFactorToken: null,
+};
 
-export function setAuthFlow(authFlow) {
+/**
+ * Set authenticationData.firstFactors from the authentication object
+ * @param {Object} authentication
+ * {
+ *   firstFactors,
+ *   secondFactors
+ * }
+ * @returns
+ */
+export function setFirstFactors(authentication) {
   // If we're not initialized, there are no first factors.
   if (!store.tenantId) {
-    console.warn("mfa/setAuthFlow: tried to set auth flow without a tenantId set.")
+    console.warn(
+      "setFirstFactors: tried to set factors without a tenantId set."
+    );
     return;
   }
   // If we're passed an invalid argument, keep the auth flow as is.
-  if (!authFlow || !typeof authFlow === "object" || !authFlow.firstFactors) {
-    console.warn("mfa/setAuthFlow: invalid auth flow passed.")
+  if (
+    !authentication ||
+    typeof authentication !== "object" ||
+    !authentication.firstFactors
+  ) {
+    console.warn("setFirstFactors: invalid factors passed.");
     return;
   }
   try {
-    mfaData.firstFactors = authFlow.firstFactors;
+    authenticationData.firstFactors = authentication.firstFactors;
     return;
   } catch (err) {
-    console.warn(`mfa/setAuthFlow: error when building factors list - ${err.message}`)
+    console.warn(
+      `setFirstFactors: error when building factors list - ${err.message}`
+    );
   }
 }
 
@@ -32,7 +48,7 @@ export function setAuthFlow(authFlow) {
  * @returns {Boolean} true if MFA is currently required
  */
 export function isMfaRequired() {
-  return !!mfaData.firstFactorToken;
+  return !!authenticationData.firstFactorToken;
 }
 
 /**
@@ -40,7 +56,7 @@ export function isMfaRequired() {
  * Adds secondFactors and firstFactorToken if it is a MFA Required response,
  * removes them if it is a successful signup or login,
  * leaves the service unchanged otherwise.
- * @param {Object} response 
+ * @param {Object} response
  */
 export function handleMfaRequired(response) {
   if (!response.isMfaRequired) {
@@ -51,8 +67,8 @@ export function handleMfaRequired(response) {
     }
     return;
   }
-  mfaData.secondFactors = response.authentication.secondFactors;
-  mfaData.firstFactorToken = response.firstFactorToken;
+  authenticationData.secondFactors = response.authentication.secondFactors;
+  authenticationData.firstFactorToken = response.firstFactorToken;
 }
 
 /**
@@ -61,12 +77,12 @@ export function handleMfaRequired(response) {
  * @returns {Object} a headers object with MFA authorization header set, or empty if MFA is not required
  */
 export function getMfaHeaders() {
-  if (mfaData.firstFactorToken) {
+  if (authenticationData.firstFactorToken) {
     return {
-      authorization: `Bearer ${mfaData.firstFactorToken}`
-    }
+      authorization: `Bearer ${authenticationData.firstFactorToken}`,
+    };
   }
-  return {}
+  return {};
 }
 
 /**
@@ -74,8 +90,8 @@ export function getMfaHeaders() {
  * leaving the tenant's persistent state in place.
  */
 export function clearMfa() {
-  mfaData.secondFactors = [];
-  mfaData.firstFactorToken = null;
+  authenticationData.secondFactors = [];
+  authenticationData.firstFactorToken = null;
 }
 
 /**
@@ -84,5 +100,5 @@ export function clearMfa() {
  */
 export function resetMfa() {
   clearMfa();
-  mfaData.firstFactors = [];
+  authenticationData.firstFactors = [];
 }

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,12 @@ function init(tenantId, opts = {}) {
   setTokenNames();
   // setIframe(); // TODO re-enable when iframe is needed
   setTokensFromCookies();
+
+  // Estimate the mode synchronously with local data.
+  // Clients that require the true mode or the default
+  // auth flow should call and await setMode.
   setModeSync();
+
   resetMfa();
 
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import { user } from "./user.js";
 import "./user.methods.js";
 import { refresh } from "./refresh.js";
 import { apiUrl } from "./constants.js";
+import { resetMfa } from "./mfa.js";
 
 let initCallbacks = [];
 
@@ -49,6 +50,7 @@ function init(tenantId, opts = {}) {
   // setIframe(); // TODO re-enable when iframe is needed
   setTokensFromCookies();
   setModeSync();
+  resetMfa();
 
   try {
     if (initCallbacks.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import { user } from "./user.js";
 import "./user.methods.js";
 import { refresh } from "./refresh.js";
 import { apiUrl } from "./constants.js";
-import { resetMfa } from "./mfa.js";
+import { resetMfa } from "./authentication.js";
 
 let initCallbacks = [];
 

--- a/src/link.js
+++ b/src/link.js
@@ -4,7 +4,11 @@ import { store } from "./store.js";
 import { getQueryAttr, handleRedirect } from "./url.js";
 import { exchange } from "./refresh.js";
 import { throwFormattedError } from "./utils.js";
-import { getMfaHeaders, handleMfaRequired, clearMfa } from "./mfa.js";
+import {
+  getMfaHeaders,
+  handleMfaRequired,
+  clearMfa,
+} from "./authentication.js";
 
 /**
  * Log a user in with a token/uuid combo passed into the function or
@@ -19,13 +23,17 @@ export async function loginWithLink({ token, uuid, redirect } = {}) {
     uuid = uuid || getQueryAttr("uuid");
     if (!token || !uuid) return;
 
-    const { data } = await put("/auth/link", {
-      token,
-      uuid,
-      tenantId: store.tenantId,
-    }, {
-      headers: getMfaHeaders()
-    });
+    const { data } = await put(
+      "/auth/link",
+      {
+        token,
+        uuid,
+        tenantId: store.tenantId,
+      },
+      {
+        headers: getMfaHeaders(),
+      }
+    );
 
     if (data.hasOwnProperty("tokens")) {
       clearMfa();

--- a/src/link.js
+++ b/src/link.js
@@ -35,7 +35,7 @@ export async function loginWithLink({ token, uuid, redirect } = {}) {
       return data;
     }
 
-    if (data.hasOwnProperty("firstFactorCode")) {
+    if (data.hasOwnProperty("firstFactorToken")) {
       handleMfaRequired(data);
       return data;
     }

--- a/src/link.js
+++ b/src/link.js
@@ -4,6 +4,7 @@ import { store } from "./store.js";
 import { getQueryAttr, handleRedirect } from "./url.js";
 import { exchange } from "./refresh.js";
 import { throwFormattedError } from "./utils.js";
+import { getMfaHeaders, handleMfaRequired, clearMfa } from "./mfa.js";
 
 /**
  * Log a user in with a token/uuid combo passed into the function or
@@ -22,9 +23,12 @@ export async function loginWithLink({ token, uuid, redirect } = {}) {
       token,
       uuid,
       tenantId: store.tenantId,
+    }, {
+      headers: getMfaHeaders()
     });
 
     if (data.hasOwnProperty("tokens")) {
+      clearMfa();
       setCookiesAndTokens(data.tokens);
       await exchange(data);
       handleRedirect({ redirect, data });
@@ -32,6 +36,7 @@ export async function loginWithLink({ token, uuid, redirect } = {}) {
     }
 
     if (data.hasOwnProperty("firstFactorCode")) {
+      handleMfaRequired(data);
       return data;
     }
 

--- a/src/mfa.js
+++ b/src/mfa.js
@@ -1,43 +1,82 @@
 import { store } from "./store.js";
 import { get } from "./api.js";
 
+// Data specific to the MFA service
 export const mfaData = {
   firstFactors: [],
   secondFactors: [],
   firstFactorToken: null
 }
 
+/**
+ * Convert a factor object to its corresponding string.
+ * @param {Object} factor a factor as { strategy, channel } 
+ * @returns {String} the factor as "strategy:channel"
+ */
 export function factorToString({ strategy, channel }) {
   return `${channel}:${strategy}`;
 }
 
+/**
+ * If initialized with a tenant ID, try to fetch the allowed first factors from the server
+ * and update the MFA service accordingly.
+ * @returns {[String]} list of acceptable first factors
+ */
 export async function updateFirstFactors() {
+  // If we're not initialized, there are no first factors.
   if (!store.tenantId) {
     return mfaData.firstFactors = [];
   }
   try {
+    // Update the first factors from the tenant's default auth flow
     const authFlow = await get(`/tenants/${store.tenantId}/flows/default`);
     if (!authFlow || !authFlow.firstFactors) {
+      // If the default auth flow is empty, there are no first factors.
       return mfaData.firstFactors = [];
     }
     return mfaData.firstFactors = authFlow.firstFactors.map(factor => factorToString(factor));
   } catch (err) {
+    // If we get an error, leave the existing factors unchanged.
+    // (This implies that if we get an Unauthorized error, the first factors
+    //  would still be empty. The first factors will only have content if we
+    //  previously got them for this tenant.)
     return mfaData.firstFactors;
   }
 }
 
+/**
+ * Check if MFA is required for the ongoing signup or login flow.
+ * @returns {Boolean} true if MFA is currently required
+ */
 export function isMfaRequired() {
   return !!mfaData.firstFactorToken;
 }
 
+/**
+ * Update the MFA service state given a response to a signup or login call.
+ * Adds secondFactors and firstFactorToken if it is a MFA Required response,
+ * removes them if it is a successful signup or login,
+ * leaves the service unchanged otherwise.
+ * @param {Object} response 
+ */
 export function handleMfaRequired(response) {
   if (!response.isMfaRequired) {
+    // If we've logged in or signed up successfully,
+    // clear the MFA service state.
+    if (response.message === "OK") {
+      clearMfa();
+    }
     return;
   }
   mfaData.secondFactors = response.authentication.secondFactors.map(factor => factorToString(factor));
   mfaData.firstFactorToken = response.firstFactorToken;
 }
 
+/**
+ * If MFA is required, returns a headers object with authorization set to the firstFactorToken.
+ * Otherwise, returns an empty object.
+ * @returns {Object} a headers object with MFA authorization header set, or empty if MFA is not required
+ */
 export function getMfaHeaders() {
   if (mfaData.firstFactorToken) {
     return {
@@ -47,11 +86,19 @@ export function getMfaHeaders() {
   return {}
 }
 
+/**
+ * Clears the current transient state of the MFA service,
+ * leaving the tenant's persistent state in place.
+ */
 export function clearMfa() {
   mfaData.secondFactors = [];
   mfaData.firstFactorToken = null;
 }
 
+/**
+ * Fully resets the MFA service, including the tenant's persistent state,
+ * to it uninitialized state.
+ */
 export function resetMfa() {
   clearMfa();
   mfaData.firstFactors = [];

--- a/src/mfa.js
+++ b/src/mfa.js
@@ -7,7 +7,7 @@ export const mfaData = {
   firstFactorToken: null
 }
 
-function factorToString({ strategy, channel }) {
+export function factorToString({ strategy, channel }) {
   return `${channel}:${strategy}`;
 }
 
@@ -15,11 +15,15 @@ export async function updateFirstFactors() {
   if (!store.tenantId) {
     return mfaData.firstFactors = [];
   }
-  const authFlow = await get(`/tenants/${store.tenantId}/flows/default`);
-  if (!authFlow) {
-    return null;
+  try {
+    const authFlow = await get(`/tenants/${store.tenantId}/flows/default`);
+    if (!authFlow || !authFlow.firstFactors) {
+      return mfaData.firstFactors = [];
+    }
+    return mfaData.firstFactors = authFlow.firstFactors.map(factor => factorToString(factor));
+  } catch (err) {
+    return mfaData.firstFactors;
   }
-  return mfaData.firstFactors = authFlow.firstFactors.map(factor => factorToString(factor));
 }
 
 export function isMfaRequired() {

--- a/src/mfa.js
+++ b/src/mfa.js
@@ -1,0 +1,54 @@
+import { store } from "./store.js";
+import { get } from "./api.js";
+
+export const mfaData = {
+  firstFactors: [],
+  secondFactors: [],
+  firstFactorToken: null
+}
+
+function factorToString({ strategy, channel }) {
+  return `${channel}:${strategy}`;
+}
+
+export async function updateFirstFactors() {
+  if (!store.tenantId) {
+    return mfaData.firstFactors = [];
+  }
+  const authFlow = await get(`/tenants/${store.tenantId}/flows/default`);
+  if (!authFlow) {
+    return null;
+  }
+  return mfaData.firstFactors = authFlow.firstFactors.map(factor => factorToString(factor));
+}
+
+export function isMfaRequired() {
+  return !!mfaData.firstFactorToken;
+}
+
+export function handleMfaRequired(response) {
+  if (!response.isMfaRequired) {
+    return;
+  }
+  mfaData.secondFactors = response.authentication.secondFactors.map(factor => factorToString(factor));
+  mfaData.firstFactorToken = response.firstFactorToken;
+}
+
+export function getMfaHeaders() {
+  if (mfaData.firstFactorToken) {
+    return {
+      authorization: `Bearer ${mfaData.firstFactorToken}`
+    }
+  }
+  return {}
+}
+
+export function clearMfa() {
+  mfaData.secondFactors = [];
+  mfaData.firstFactorToken = null;
+}
+
+export function resetMfa() {
+  clearMfa();
+  mfaData.firstFactors = [];
+}

--- a/src/mfa.js
+++ b/src/mfa.js
@@ -14,7 +14,7 @@ export const mfaData = {
  * @returns {String} the factor as "strategy:channel"
  */
 export function factorToString({ strategy, channel }) {
-  return `${channel}:${strategy}`;
+  return `${strategy}:${channel}`;
 }
 
 /**

--- a/src/mode.js
+++ b/src/mode.js
@@ -46,6 +46,7 @@ export async function setMode() {
     mode.reason = getReason(mode.value);
     store.mode = mode.value;
     setFirstFactors(data.authentication);
+    return data;
   } catch (err) {
     mode.value = "test";
     store.mode = mode.value;

--- a/src/mode.js
+++ b/src/mode.js
@@ -1,6 +1,7 @@
 import { get } from "./api.js";
 import { privateIPRegex } from "./constants.js";
 import { store } from "./store.js";
+import { setAuthFlow } from "./mfa.js";
 
 /**
  * Global mode object
@@ -36,6 +37,7 @@ export function isHttps() {
 
 /**
  * Define the mode of operation (live or test)
+ * and the tenant's default auth flow
  */
 export async function setMode() {
   try {
@@ -43,6 +45,7 @@ export async function setMode() {
     mode.value = data.mode || "test";
     mode.reason = getReason(mode.value);
     store.mode = mode.value;
+    setAuthFlow(data);
   } catch (err) {
     mode.value = "test";
     store.mode = mode.value;

--- a/src/mode.js
+++ b/src/mode.js
@@ -1,7 +1,7 @@
 import { get } from "./api.js";
 import { privateIPRegex } from "./constants.js";
 import { store } from "./store.js";
-import { setAuthFlow } from "./mfa.js";
+import { setFirstFactors } from "./authentication.js";
 
 /**
  * Global mode object
@@ -45,7 +45,7 @@ export async function setMode() {
     mode.value = data.mode || "test";
     mode.reason = getReason(mode.value);
     store.mode = mode.value;
-    setAuthFlow(data);
+    setFirstFactors(data.authentication);
   } catch (err) {
     mode.value = "test";
     store.mode = mode.value;

--- a/src/password.js
+++ b/src/password.js
@@ -80,7 +80,7 @@ export async function loginWithPassword({
       return data;
     }
 
-    if (data.hasOwnProperty("firstFactorCode")) {
+    if (data.hasOwnProperty("firstFactorToken")) {
       handleMfaRequired(data);
       return data;
     }

--- a/src/password.js
+++ b/src/password.js
@@ -4,7 +4,11 @@ import { store } from "./store.js";
 import { getQueryAttr, handleRedirect } from "./url.js";
 import { throwFormattedError } from "./utils.js";
 import { exchange } from "./refresh.js";
-import { getMfaHeaders, handleMfaRequired, clearMfa } from "./mfa.js";
+import {
+  getMfaHeaders,
+  handleMfaRequired,
+  clearMfa,
+} from "./authentication.js";
 
 /**
  * Register a new user with username, name, email, and password.
@@ -25,16 +29,20 @@ export async function signupWithPassword({
   redirect,
 } = {}) {
   try {
-    const { data } = await post(`/auth/create`, {
-      tenantId: store.tenantId,
-      username,
-      name,
-      email,
-      password,
-      data: userData,
-    }, {
-      headers: getMfaHeaders()
-    });
+    const { data } = await post(
+      `/auth/create`,
+      {
+        tenantId: store.tenantId,
+        username,
+        name,
+        email,
+        password,
+        data: userData,
+      },
+      {
+        headers: getMfaHeaders(),
+      }
+    );
     if (data.tokens) {
       clearMfa();
       setCookiesAndTokens(data.tokens);
@@ -65,13 +73,17 @@ export async function loginWithPassword({
   redirect,
 }) {
   try {
-    const { data } = await post(`/auth/basic`, {
-      tenantId: store.tenantId,
-      emailOrUsername: email || username || emailOrUsername,
-      password,
-    }, {
-      headers: getMfaHeaders()
-    });
+    const { data } = await post(
+      `/auth/basic`,
+      {
+        tenantId: store.tenantId,
+        emailOrUsername: email || username || emailOrUsername,
+        password,
+      },
+      {
+        headers: getMfaHeaders(),
+      }
+    );
 
     if (data.hasOwnProperty("tokens")) {
       setCookiesAndTokens(data.tokens);

--- a/src/session.js
+++ b/src/session.js
@@ -1,7 +1,13 @@
 import {
   isAccessTokenLocallyValid,
-  isRefreshTokenLocallyValid,
+  isRefreshTokenLocallyValid
 } from "./tokens.js";
+import {
+  mfaData,
+  updateFirstFactors,
+  isMfaRequired,
+  clearMfa
+} from "./mfa.js";
 import { refresh } from "./refresh.js";
 
 /**
@@ -38,5 +44,14 @@ async function getIsLoggedIn() {
  */
 export async function getSession() {
   const isLoggedIn = await getIsLoggedIn();
-  return { isLoggedIn };
+  if (!isLoggedIn) {
+    await updateFirstFactors();
+  }
+  return {
+    isLoggedIn,
+    needsSecondFactor: isMfaRequired(),
+    firstFactors: mfaData.firstFactors,
+    secondFactors: mfaData.secondFactors,
+    resetMfaState: clearMfa
+  };
 }

--- a/src/session.js
+++ b/src/session.js
@@ -1,12 +1,12 @@
 import {
   isAccessTokenLocallyValid,
-  isRefreshTokenLocallyValid
+  isRefreshTokenLocallyValid,
 } from "./tokens.js";
 import {
-  mfaData,
+  authenticationData,
   isMfaRequired,
-  clearMfa
-} from "./mfa.js";
+  clearMfa,
+} from "./authentication.js";
 import { refresh } from "./refresh.js";
 
 /**
@@ -46,8 +46,8 @@ export async function getSession() {
   return {
     isLoggedIn,
     needsSecondFactor: isMfaRequired(),
-    firstFactors: mfaData.firstFactors,
-    secondFactors: mfaData.secondFactors,
-    resetMfaState: clearMfa
+    firstFactors: authenticationData.firstFactors,
+    secondFactors: authenticationData.secondFactors,
+    resetMfaState: clearMfa,
   };
 }

--- a/src/session.js
+++ b/src/session.js
@@ -4,7 +4,6 @@ import {
 } from "./tokens.js";
 import {
   mfaData,
-  updateFirstFactors,
   isMfaRequired,
   clearMfa
 } from "./mfa.js";
@@ -44,9 +43,6 @@ async function getIsLoggedIn() {
  */
 export async function getSession() {
   const isLoggedIn = await getIsLoggedIn();
-  if (!isLoggedIn) {
-    await updateFirstFactors();
-  }
   return {
     isLoggedIn,
     needsSecondFactor: isMfaRequired(),

--- a/src/totp.js
+++ b/src/totp.js
@@ -4,7 +4,12 @@ import { store } from "./store.js";
 import { handleRedirect } from "./url.js";
 import { exchange } from "./refresh.js";
 import { throwFormattedError } from "./utils.js";
-import { isMfaRequired, getMfaHeaders, handleMfaRequired, clearMfa } from "./mfa.js";
+import {
+  isMfaRequired,
+  getMfaHeaders,
+  handleMfaRequired,
+  clearMfa,
+} from "./authentication.js";
 
 /**
  * Log a user in with a TOTP authenticator code or a TOTP backup code,
@@ -34,19 +39,23 @@ export async function loginWithTotp({
   try {
     if (!totpCode && !backupCode) return;
 
-    const { data } = await post(`/auth/totp`, {
-      totpCode,
-      backupCode,
-      userId,
-      userUuid,
-      emailOrUsername,
-      email,
-      username,
-      phoneNumber,
-      tenantId: store.tenantId,
-    }, {
-      headers: getMfaHeaders()
-    });
+    const { data } = await post(
+      `/auth/totp`,
+      {
+        totpCode,
+        backupCode,
+        userId,
+        userUuid,
+        emailOrUsername,
+        email,
+        username,
+        phoneNumber,
+        tenantId: store.tenantId,
+      },
+      {
+        headers: getMfaHeaders(),
+      }
+    );
 
     if (data.hasOwnProperty("tokens")) {
       clearMfa();

--- a/src/totp.js
+++ b/src/totp.js
@@ -56,7 +56,7 @@ export async function loginWithTotp({
       return data;
     }
 
-    if (data.hasOwnProperty("firstFactorCode")) {
+    if (data.hasOwnProperty("firstFactorToken")) {
       handleMfaRequired(data);
       return data;
     }

--- a/src/verificationCode.js
+++ b/src/verificationCode.js
@@ -101,7 +101,7 @@ export async function loginWithVerificationCode({
       return data;
     }
 
-    if (data.hasOwnProperty("firstFactorCode")) {
+    if (data.hasOwnProperty("firstFactorToken")) {
       handleMfaRequired(data);
       return data;
     }

--- a/src/verificationCode.js
+++ b/src/verificationCode.js
@@ -4,6 +4,7 @@ import { store } from "./store.js";
 import { handleRedirect } from "./url.js";
 import { exchange } from "./refresh.js";
 import { throwFormattedError } from "./utils.js";
+import { getMfaHeaders, handleMfaRequired, clearMfa } from "./mfa.js";
 
 /**
  * Verify that proper identifier is available for the channel
@@ -88,9 +89,12 @@ export async function loginWithVerificationCode({
       email,
       phoneNumber,
       tenantId: store.tenantId,
+    }, {
+      headers: getMfaHeaders()
     });
 
     if (data.hasOwnProperty("tokens")) {
+      clearMfa();
       setCookiesAndTokens(data.tokens);
       await exchange(data);
       handleRedirect({ redirect, data });
@@ -98,6 +102,7 @@ export async function loginWithVerificationCode({
     }
 
     if (data.hasOwnProperty("firstFactorCode")) {
+      handleMfaRequired(data);
       return data;
     }
 

--- a/src/verificationCode.js
+++ b/src/verificationCode.js
@@ -4,7 +4,11 @@ import { store } from "./store.js";
 import { handleRedirect } from "./url.js";
 import { exchange } from "./refresh.js";
 import { throwFormattedError } from "./utils.js";
-import { getMfaHeaders, handleMfaRequired, clearMfa } from "./mfa.js";
+import {
+  getMfaHeaders,
+  handleMfaRequired,
+  clearMfa,
+} from "./authentication.js";
 
 /**
  * Verify that proper identifier is available for the channel
@@ -83,15 +87,19 @@ export async function loginWithVerificationCode({
       email,
     });
 
-    const { data } = await put(`/auth/code`, {
-      channel,
-      verificationCode,
-      email,
-      phoneNumber,
-      tenantId: store.tenantId,
-    }, {
-      headers: getMfaHeaders()
-    });
+    const { data } = await put(
+      `/auth/code`,
+      {
+        channel,
+        verificationCode,
+        email,
+        phoneNumber,
+        tenantId: store.tenantId,
+      },
+      {
+        headers: getMfaHeaders(),
+      }
+    );
 
     if (data.hasOwnProperty("tokens")) {
       clearMfa();

--- a/test/authentication.spec.js
+++ b/test/authentication.spec.js
@@ -121,7 +121,58 @@ describe("Authentication service", () => {
           channel: "sms",
         },
       ]);
+      expect(authenticationData.firstFactorToken).toEqual("uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a")
     });
+    it("should overwrite the firstFactorToken on sequential successful first factor logins", () => {
+      const firstFactorToken1 = "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a"
+      const mockResponse1 = {
+        message: "MFA required",
+        isMfaRequired: true,
+        firstFactorToken: firstFactorToken1,
+        authentication: {
+          firstFactor: {
+            strategy: "link",
+            channel: "email",
+          },
+          secondFactors: [
+            {
+              strategy: "totp",
+              channel: "authenticator",
+            },
+            {
+              strategy: "verificationCode",
+              channel: "sms",
+            },
+          ],
+        },
+      };
+      handleMfaRequired(mockResponse1);
+      expect(authenticationData.firstFactorToken).toEqual(firstFactorToken1);
+      const firstFactorToken2 = "uf_test_first_factor_12345d56ce7e4ae3677ea0918fbabcde"
+      const mockResponse2 = {
+        message: "MFA required",
+        isMfaRequired: true,
+        firstFactorToken: firstFactorToken2,
+        authentication: {
+          firstFactor: {
+            strategy: "link",
+            channel: "email",
+          },
+          secondFactors: [
+            {
+              strategy: "totp",
+              channel: "authenticator",
+            },
+            {
+              strategy: "verificationCode",
+              channel: "sms",
+            },
+          ],
+        },
+      };
+      handleMfaRequired(mockResponse2);
+      expect(authenticationData.firstFactorToken).toEqual(firstFactorToken2)
+    })
   });
 
   describe("getMfaHeaders()", () => {

--- a/test/config/assertions.js
+++ b/test/config/assertions.js
@@ -1,0 +1,25 @@
+import { mfaData, getMfaHeaders } from "../../src/mfa.js";
+
+export function assertMfaStateMatches(mfaRequiredResponse) {
+  expect(mfaData.secondFactors).toEqual(mfaRequiredResponse.authorization.secondFactors)
+  expect(mfaData.firstFactorToken).toEqual(mfaRequiredResponse.firstFactorToken)
+}
+
+export function assertMfaHeadersPresent(mockApiFn) {
+  expect(mfaData.firstFactorToken).not.toBeNull();
+  expect(mockApiFn.mock.lastCall[2]).toEqual({
+    headers: {
+      authorization: `Bearer ${mfaData.firstFactorToken}`
+    }
+  })
+}
+
+export function assertMfaHeadersAbsent(mockApiFn) {
+  const options = mockApiFn.mock.lastcall[2]
+  const mfaHeaders = getMfaHeaders();
+  if (mfaHeaders.authorization) {
+    if (options.headers && options.headers.authorization) {
+      expect(options.headers.authorization).not.toEqual(mfaHeaders.authorization)
+    }
+  }
+}

--- a/test/config/assertions.js
+++ b/test/config/assertions.js
@@ -1,7 +1,7 @@
-import { mfaData, factorToString } from "../../src/mfa.js";
+import { mfaData, getMfaHeaders } from "../../src/mfa.js";
 
 export function assertMfaStateMatches(mfaRequiredResponse) {
-  expect(mfaData.secondFactors).toEqual(mfaRequiredResponse.data.authentication.secondFactors.map(factorToString))
+  expect(mfaData.secondFactors).toEqual(mfaRequiredResponse.data.authentication.secondFactors)
   expect(mfaData.firstFactorToken).toEqual(mfaRequiredResponse.data.firstFactorToken)
 }
 

--- a/test/config/assertions.js
+++ b/test/config/assertions.js
@@ -1,28 +1,42 @@
-import { mfaData, getMfaHeaders } from "../../src/mfa.js";
+import { authenticationData, getMfaHeaders } from "../../src/authentication.js";
 
 export function assertMfaStateMatches(mfaRequiredResponse) {
-  expect(mfaData.secondFactors).toEqual(mfaRequiredResponse.data.authentication.secondFactors)
-  expect(mfaData.firstFactorToken).toEqual(mfaRequiredResponse.data.firstFactorToken)
+  expect(authenticationData.secondFactors).toEqual(
+    mfaRequiredResponse.data.authentication.secondFactors
+  );
+  expect(authenticationData.firstFactorToken).toEqual(
+    mfaRequiredResponse.data.firstFactorToken
+  );
 }
 
 export function assertNoUser(user) {
-  const userFields = Object.values(user).filter(val => typeof val !== "function");
+  const userFields = Object.values(user).filter(
+    (val) => typeof val !== "function"
+  );
   expect(userFields).toEqual([]);
 }
 
-export const mfaHeaders = expect.objectContaining({ headers: { authorization: expect.stringMatching(/^Bearer uf_test_first_factor/) } })
-export const noMfaHeaders = expect.not.objectContaining({ headers: { authorization: expect.stringMatching(/^Bearer uf_test_first_factor/) } })
+export const mfaHeaders = expect.objectContaining({
+  headers: {
+    authorization: expect.stringMatching(/^Bearer uf_test_first_factor/),
+  },
+});
+export const noMfaHeaders = expect.not.objectContaining({
+  headers: {
+    authorization: expect.stringMatching(/^Bearer uf_test_first_factor/),
+  },
+});
 
 export const withMfaHeaders = (options = {}) => {
   return {
     ...options,
-    headers: getMfaHeaders()
-  }
-}
+    headers: getMfaHeaders(),
+  };
+};
 
 export const withoutMfaHeaders = (options) => {
   if (!options) {
     return noMfaHeaders;
   }
-  return options
-}
+  return options;
+};

--- a/test/config/utils.js
+++ b/test/config/utils.js
@@ -1,4 +1,5 @@
 import { isTestHostname } from "../../src/mode.js";
+import { mfaData } from "../../src/mfa.js"; 
 import jwt from "jsonwebtoken";
 
 export function resetStore(Userfront) {
@@ -121,6 +122,53 @@ export function createRefreshToken(payload = {}) {
   };
   delete jwtPayload.authorization;
   return jwt.sign(jwtPayload, testRsaPrivateKey, { algorithm: "RS256" });
+}
+
+export function createFirstFactorToken() {
+  // The first factor token is arbitrary and opaque from the client's perspective
+  return "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a"
+}
+
+export function createMfaRequiredResponse({ mode, firstFactor, secondFactors }) {
+  const _firstFactor = firstFactor || {
+    strategy: "password",
+    channel: "email"
+  }
+  const _secondFactors = secondFactors || [
+    {
+      strategy: "totp",
+      channel: "authenticator"
+    },
+    {
+      strategy: "verificationCode",
+      channel: "sms"
+    }
+  ]
+  const response = {
+    mode: mode || "live",
+    message: "MFA required",
+    isMfaRequired: true,
+    firstFactorToken: createFirstFactorToken(),
+    authentication: {
+      firstFactor: _firstFactor,
+      secondFactors: _secondFactors
+    }
+  }
+  return { data: response };
+}
+
+export function setMfaRequired() {
+  mfaData.secondFactors = [
+    {
+      strategy: "totp",
+      channel: "authenticator"
+    },
+    {
+      strategy: "verificationCode",
+      channel: "sms"
+    }
+  ]
+  mfaData.firstFactorToken = createFirstFactorToken();
 }
 
 export function addMinutes(date, minutes) {

--- a/test/config/utils.js
+++ b/test/config/utils.js
@@ -1,5 +1,5 @@
 import { isTestHostname } from "../../src/mode.js";
-import { mfaData } from "../../src/mfa.js"; 
+import { authenticationData } from "../../src/authentication.js";
 import jwt from "jsonwebtoken";
 
 export function resetStore(Userfront) {
@@ -126,24 +126,28 @@ export function createRefreshToken(payload = {}) {
 
 export function createFirstFactorToken() {
   // The first factor token is arbitrary and opaque from the client's perspective
-  return "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a"
+  return "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a";
 }
 
-export function createMfaRequiredResponse({ mode, firstFactor, secondFactors }) {
+export function createMfaRequiredResponse({
+  mode,
+  firstFactor,
+  secondFactors,
+}) {
   const _firstFactor = firstFactor || {
     strategy: "password",
-    channel: "email"
-  }
+    channel: "email",
+  };
   const _secondFactors = secondFactors || [
     {
       strategy: "totp",
-      channel: "authenticator"
+      channel: "authenticator",
     },
     {
       strategy: "verificationCode",
-      channel: "sms"
-    }
-  ]
+      channel: "sms",
+    },
+  ];
   const response = {
     mode: mode || "live",
     message: "MFA required",
@@ -151,24 +155,24 @@ export function createMfaRequiredResponse({ mode, firstFactor, secondFactors }) 
     firstFactorToken: createFirstFactorToken(),
     authentication: {
       firstFactor: _firstFactor,
-      secondFactors: _secondFactors
-    }
-  }
+      secondFactors: _secondFactors,
+    },
+  };
   return { data: response };
 }
 
 export function setMfaRequired() {
-  mfaData.secondFactors = [
+  authenticationData.secondFactors = [
     {
       strategy: "totp",
-      channel: "authenticator"
+      channel: "authenticator",
     },
     {
       strategy: "verificationCode",
-      channel: "sms"
-    }
-  ]
-  mfaData.firstFactorToken = createFirstFactorToken();
+      channel: "sms",
+    },
+  ];
+  authenticationData.firstFactorToken = createFirstFactorToken();
 }
 
 export function addMinutes(date, minutes) {

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -5,6 +5,9 @@ import {
   resetStore,
   mockWindow,
 } from "./config/utils.js";
+import {
+  noMfaHeaders
+} from "./config/assertions.js";
 import Userfront from "../src/index.js";
 import { setMode } from "../src/mode.js";
 import { store } from "../src/store.js";
@@ -91,7 +94,7 @@ describe("init() method with domain option", () => {
         data: undefined,
         tenantId,
       },
-      undefined
+      noMfaHeaders
     );
   });
 
@@ -115,7 +118,7 @@ describe("init() method with domain option", () => {
         password,
         tenantId,
       },
-      undefined
+      noMfaHeaders
     );
   });
 

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -5,9 +5,7 @@ import {
   resetStore,
   mockWindow,
 } from "./config/utils.js";
-import {
-  noMfaHeaders
-} from "./config/assertions.js";
+import { noMfaHeaders } from "./config/assertions.js";
 import Userfront from "../src/index.js";
 import { setMode } from "../src/mode.js";
 import { store } from "../src/store.js";
@@ -57,10 +55,12 @@ describe("init() method with domain option", () => {
       status: 200,
       data: {
         mode: "live",
-        firstFactors: [],
-        secondFactors: [],
-        isMfaRequired: false,
-        isEnabled: false
+        authentication: {
+          firstFactors: [],
+          secondFactors: [],
+          isMfaRequired: false,
+          isEnabled: false,
+        },
       },
     });
     await setMode();

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -57,6 +57,10 @@ describe("init() method with domain option", () => {
       status: 200,
       data: {
         mode: "live",
+        firstFactors: [],
+        secondFactors: [],
+        isMfaRequired: false,
+        isEnabled: false
       },
     });
     await setMode();

--- a/test/mfa.spec.js
+++ b/test/mfa.spec.js
@@ -45,13 +45,13 @@ describe("mfa.js - MFA service", () => {
       expect(api.get).toHaveBeenCalledWith("/tenants/demo1234/flows/default");
       
       expect(mfaData.firstFactors).toEqual([
-        "email:password",
-        "email:link"
+        "password:email",
+        "link:email"
       ])
 
       expect(firstFactors).toEqual([
-        "email:password",
-        "email:link"
+        "password:email",
+        "link:email"
       ])
     });
     it("should clear the available first factors if the library hasn't been initialized with a tenantId", async () =>{
@@ -86,8 +86,8 @@ describe("mfa.js - MFA service", () => {
       api.get.mockImplementationOnce(() => Promise.reject(mockResponse));
       Userfront.init("demo1234");
       const existingFirstFactors = [
-        "email:password",
-        "sms:verificationCode"
+        "password:email",
+        "verificationCode:sms"
       ]
       mfaData.firstFactors = [...existingFirstFactors];
 
@@ -102,8 +102,8 @@ describe("mfa.js - MFA service", () => {
       api.get.mockImplementationOnce(() => mockResponse);
       Userfront.init("demo1234")
       mfaData.firstFactors = [
-        "email:link",
-        "email:verificationCode"
+        "link:email",
+        "verificationCode:email"
       ]
 
       const firstFactors = await updateFirstFactors();
@@ -163,8 +163,8 @@ describe("mfa.js - MFA service", () => {
       }
       handleMfaRequired(mockResponse);
       expect(mfaData.secondFactors).toEqual([
-        "authenticator:totp",
-        "sms:verificationCode"
+        "totp:authenticator",
+        "verificationCode:sms"
       ]);
     });
   });
@@ -185,29 +185,29 @@ describe("mfa.js - MFA service", () => {
 
   it("clearMfa should clear the transient MFA state", () => {
     mfaData.secondFactors = [
-      "authenticator:totp",
-      "sms:verificationCode"
+      "totp:authenticator",
+      "verificationCode:sms"
     ]
     mfaData.firstFactorToken = "uf_test_first_factor_token";
     mfaData.firstFactors = [
-      "email:password"
+      "password:email"
     ]
     clearMfa();
     expect(mfaData.secondFactors).toEqual([])
     expect(mfaData.firstFactorToken).toEqual(null);
     expect(mfaData.firstFactors).toEqual([
-      "email:password"
+      "password:email"
     ])
   })
 
   it("resetMfa should reset the MFA service to the uninitialized state", () => {
     mfaData.secondFactors = [
-      "authenticator:totp",
-      "sms:verificationCode"
+      "totp:authenticator",
+      "verificationCode:sms"
     ]
     mfaData.firstFactorToken = "uf_test_first_factor_token";
     mfaData.firstFactors = [
-      "email:password"
+      "password:email"
     ]
     resetMfa();
     expect(mfaData.secondFactors).toEqual([])

--- a/test/mfa.spec.js
+++ b/test/mfa.spec.js
@@ -1,0 +1,217 @@
+import Userfront from "../src/index.js";
+import api from "../src/api.js";
+import {
+  mfaData,
+  updateFirstFactors,
+  isMfaRequired,
+  handleMfaRequired,
+  getMfaHeaders,
+  clearMfa,
+  resetMfa
+} from "../src/mfa.js";
+
+jest.mock("../src/api.js");
+
+const blankMfaData = {
+  ...mfaData
+}
+
+describe("mfa.js - MFA service", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    for (const key in mfaData) {
+      mfaData[key] = blankMfaData[key];
+    }
+  })
+  describe("updateFirstFactors()", () => {
+    it("should update the available first factors to match the tenant's default flow", async () => {
+      const mockResponse = {
+        firstFactors: [
+          {
+            channel: "email",
+            strategy: "password"
+          },
+          {
+            channel: "email",
+            strategy: "link"
+          }
+        ]
+      }
+      api.get.mockImplementationOnce(() => mockResponse)
+
+      Userfront.init("demo1234")
+      const firstFactors = await updateFirstFactors();
+
+      expect(api.get).toHaveBeenCalledWith("/tenants/demo1234/flows/default");
+      
+      expect(mfaData.firstFactors).toEqual([
+        "email:password",
+        "email:link"
+      ])
+
+      expect(firstFactors).toEqual([
+        "email:password",
+        "email:link"
+      ])
+    });
+    it("should clear the available first factors if the library hasn't been initialized with a tenantId", async () =>{
+      const mockResponse = {
+        response: {
+          data: {
+            error: "Bad request",
+            message: "Missing tenantId.",
+            statusCode: 400
+          }
+        }
+      }
+      api.get.mockImplementationOnce(() => Promise.reject(mockResponse));
+      delete Userfront.store.tenantId;
+
+      const firstFactors = await updateFirstFactors();
+
+      expect(api.get).not.toHaveBeenCalled();
+      expect(mfaData.firstFactors).toEqual([]);
+      expect(firstFactors).toEqual([]);
+    });
+    it("should leave existing first factors in place and do nothing if the update call rejects", async () => {
+      const mockResponse = {
+        response: {
+          data: {
+            error: "Internal server error",
+            message: "Try again later",
+            statusCode: 500
+          }
+        }
+      }
+      api.get.mockImplementationOnce(() => Promise.reject(mockResponse));
+      Userfront.init("demo1234");
+      const existingFirstFactors = [
+        "email:password",
+        "sms:verificationCode"
+      ]
+      mfaData.firstFactors = [...existingFirstFactors];
+
+      const firstFactors = await updateFirstFactors();
+
+      expect(api.get).toHaveBeenCalledWith("/tenants/demo1234/flows/default");
+      expect(mfaData.firstFactors).toEqual(existingFirstFactors);
+      expect(firstFactors).toEqual(existingFirstFactors);
+    });
+    it("should clear first factors if the default auth flow is empty", async () => {
+      const mockResponse = {}
+      api.get.mockImplementationOnce(() => mockResponse);
+      Userfront.init("demo1234")
+      mfaData.firstFactors = [
+        "email:link",
+        "email:verificationCode"
+      ]
+
+      const firstFactors = await updateFirstFactors();
+
+      expect(api.get).toHaveBeenCalledWith("/tenants/demo1234/flows/default");
+      expect(mfaData.firstFactors).toEqual([]);
+      expect(firstFactors).toEqual([]);
+    });
+  });
+
+  describe("isMfaRequired()", () => {
+    it("should return true if MFA is currently required", () => {
+      mfaData.firstFactorToken = "uf_live_first_factor_sometoken";
+      expect(isMfaRequired()).toEqual(true);
+    });
+    it("should return false if MFA is not currently required", () => {
+      mfaData.firstFactorToken = "";
+      expect(isMfaRequired()).toEqual(false);
+    });
+  });
+
+  describe("handleMfaRequired()", () => {
+    it("should do nothing if the response is not an MFA Required response", () => {
+      const mockResponse = {
+        message: "OK",
+        result: {
+          channel: "sms",
+          phoneNumber: "+15558675309",
+          submittedAt: "2022-10-21T23:26:07.146Z",
+          messageId: "fe3194f6-da85-48aa-a24e-3eab4c5c19d1"
+        }
+      }
+      handleMfaRequired(mockResponse);
+      expect(mfaData).toEqual(blankMfaData);
+    });
+    it("should set the MFA service state if it is an MFA Required response", () => {
+      const mockResponse = {
+        message: "MFA required",
+        isMfaRequired: true,
+        firstFactorToken: "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a",
+        authentication: {
+          firstFactor: {
+            strategy: "link",
+            channel: "email"
+          },
+          secondFactors: [
+            {
+              strategy: "totp",
+              channel: "authenticator"
+            },
+            {
+              strategy: "verificationCode",
+              channel: "sms"
+            }
+          ]
+        }
+      }
+      handleMfaRequired(mockResponse);
+      expect(mfaData.secondFactors).toEqual([
+        "authenticator:totp",
+        "sms:verificationCode"
+      ]);
+    });
+  });
+
+  describe("getMfaHeaders()", () => {
+    it("should return an authorization header if there is a firstFactorToken set", () => {
+      mfaData.firstFactorToken = "uf_test_first_factor_token"
+      const headers = getMfaHeaders();
+      expect(headers).toEqual({
+        authorization: "Bearer uf_test_first_factor_token"
+      })
+    })
+    it("should return an empty object if there is no firstFactorToken set", () => {
+      const headers = getMfaHeaders();
+      expect(headers).toEqual({})
+    })
+  })
+
+  it("clearMfa should clear the transient MFA state", () => {
+    mfaData.secondFactors = [
+      "authenticator:totp",
+      "sms:verificationCode"
+    ]
+    mfaData.firstFactorToken = "uf_test_first_factor_token";
+    mfaData.firstFactors = [
+      "email:password"
+    ]
+    clearMfa();
+    expect(mfaData.secondFactors).toEqual([])
+    expect(mfaData.firstFactorToken).toEqual(null);
+    expect(mfaData.firstFactors).toEqual([
+      "email:password"
+    ])
+  })
+
+  it("resetMfa should reset the MFA service to the uninitialized state", () => {
+    mfaData.secondFactors = [
+      "authenticator:totp",
+      "sms:verificationCode"
+    ]
+    mfaData.firstFactorToken = "uf_test_first_factor_token";
+    mfaData.firstFactors = [
+      "email:password"
+    ]
+    resetMfa();
+    expect(mfaData.secondFactors).toEqual([])
+    expect(mfaData.firstFactorToken).toEqual(null);
+    expect(mfaData.firstFactors).toEqual([]);
+  })
+})

--- a/test/mode.spec.js
+++ b/test/mode.spec.js
@@ -1,7 +1,7 @@
 import Userfront from "../src/index.js";
 import api from "../src/api.js";
 import { isTestHostname, setMode, setModeSync } from "../src/mode.js";
-import { apiUrl } from "../src/constants.js";
+import { mfaData } from "../src/mfa.js";
 
 jest.mock("../src/api.js");
 
@@ -57,6 +57,10 @@ describe("Mode tests", () => {
         status: 200,
         data: {
           mode: "live",
+          firstFactors: [{ channel: "email", strategy: "password" }],
+          secondFactors: [],
+          isMfaRequired: false,
+          isEnabled: true
         },
       });
 
@@ -66,6 +70,7 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("live");
       expect(Userfront.mode.value).toEqual("live");
       expect(Userfront.mode.reason).toEqual("domain");
+      expect(mfaData.firstFactors).toEqual([{ channel: "email", strategy: "password" }]);
     });
 
     it("Should set reason to 'http' when setMode() returns 'test'", async () => {
@@ -77,6 +82,10 @@ describe("Mode tests", () => {
         status: 200,
         data: {
           mode: "test",
+          firstFactors: [{ channel: "email", strategy: "password" }],
+          secondFactors: [],
+          isMfaRequired: false,
+          isEnabled: true
         },
       });
 
@@ -86,6 +95,7 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("test");
       expect(Userfront.mode.value).toEqual("test");
       expect(Userfront.mode.reason).toEqual("http");
+      expect(mfaData.firstFactors).toEqual([{ channel: "email", strategy: "password" }]);
     });
 
     it("Should set reason to 'domain' when setMode() returns 'test'", async () => {
@@ -97,6 +107,10 @@ describe("Mode tests", () => {
         status: 200,
         data: {
           mode: "test",
+          firstFactors: [{ channel: "email", strategy: "password" }],
+          secondFactors: [],
+          isMfaRequired: false,
+          isEnabled: true
         },
       });
 
@@ -106,6 +120,7 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("test");
       expect(Userfront.mode.value).toEqual("test");
       expect(Userfront.mode.reason).toEqual("domain");
+      expect(mfaData.firstFactors).toEqual([{ channel: "email", strategy: "password" }]);
     });
 
     it("Should set reason to 'protocol' when setMode() returns 'test'", async () => {
@@ -117,6 +132,10 @@ describe("Mode tests", () => {
         status: 200,
         data: {
           mode: "test",
+          firstFactors: [{ channel: "email", strategy: "password" }],
+          secondFactors: [],
+          isMfaRequired: false,
+          isEnabled: true
         },
       });
 
@@ -126,7 +145,29 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("test");
       expect(Userfront.mode.value).toEqual("test");
       expect(Userfront.mode.reason).toEqual("protocol");
+      expect(mfaData.firstFactors).toEqual([{ channel: "email", strategy: "password" }]);
     });
+    
+    it("Should not fail if a default auth flow is not present", async () => {
+      window.location = new URL("https://example.com/login");
+
+      Userfront.init(tenantId);
+
+      api.get.mockResolvedValue({
+        status: 200,
+        data: {
+          mode: "live"
+        },
+      });
+
+      await setMode();
+      expect(api.get).toHaveBeenCalledWith(`/tenants/${tenantId}/mode`);
+
+      expect(Userfront.store.mode).toEqual("live");
+      expect(Userfront.mode.value).toEqual("live");
+      expect(Userfront.mode.reason).toEqual("domain");
+      expect(mfaData.firstFactors).toEqual([]);
+    })
   });
 });
 

--- a/test/mode.spec.js
+++ b/test/mode.spec.js
@@ -1,7 +1,7 @@
 import Userfront from "../src/index.js";
 import api from "../src/api.js";
 import { isTestHostname, setMode, setModeSync } from "../src/mode.js";
-import { mfaData } from "../src/mfa.js";
+import { authenticationData } from "../src/authentication.js";
 
 jest.mock("../src/api.js");
 
@@ -57,10 +57,12 @@ describe("Mode tests", () => {
         status: 200,
         data: {
           mode: "live",
-          firstFactors: [{ channel: "email", strategy: "password" }],
-          secondFactors: [],
-          isMfaRequired: false,
-          isEnabled: true
+          authentication: {
+            firstFactors: [{ channel: "email", strategy: "password" }],
+            secondFactors: [],
+            isMfaRequired: false,
+            isEnabled: true,
+          },
         },
       });
 
@@ -70,7 +72,9 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("live");
       expect(Userfront.mode.value).toEqual("live");
       expect(Userfront.mode.reason).toEqual("domain");
-      expect(mfaData.firstFactors).toEqual([{ channel: "email", strategy: "password" }]);
+      expect(authenticationData.firstFactors).toEqual([
+        { channel: "email", strategy: "password" },
+      ]);
     });
 
     it("Should set reason to 'http' when setMode() returns 'test'", async () => {
@@ -82,10 +86,12 @@ describe("Mode tests", () => {
         status: 200,
         data: {
           mode: "test",
-          firstFactors: [{ channel: "email", strategy: "password" }],
-          secondFactors: [],
-          isMfaRequired: false,
-          isEnabled: true
+          authentication: {
+            firstFactors: [{ channel: "email", strategy: "password" }],
+            secondFactors: [],
+            isMfaRequired: false,
+            isEnabled: true,
+          },
         },
       });
 
@@ -95,7 +101,9 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("test");
       expect(Userfront.mode.value).toEqual("test");
       expect(Userfront.mode.reason).toEqual("http");
-      expect(mfaData.firstFactors).toEqual([{ channel: "email", strategy: "password" }]);
+      expect(authenticationData.firstFactors).toEqual([
+        { channel: "email", strategy: "password" },
+      ]);
     });
 
     it("Should set reason to 'domain' when setMode() returns 'test'", async () => {
@@ -107,10 +115,12 @@ describe("Mode tests", () => {
         status: 200,
         data: {
           mode: "test",
-          firstFactors: [{ channel: "email", strategy: "password" }],
-          secondFactors: [],
-          isMfaRequired: false,
-          isEnabled: true
+          authentication: {
+            firstFactors: [{ channel: "email", strategy: "password" }],
+            secondFactors: [],
+            isMfaRequired: false,
+            isEnabled: true,
+          },
         },
       });
 
@@ -120,7 +130,9 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("test");
       expect(Userfront.mode.value).toEqual("test");
       expect(Userfront.mode.reason).toEqual("domain");
-      expect(mfaData.firstFactors).toEqual([{ channel: "email", strategy: "password" }]);
+      expect(authenticationData.firstFactors).toEqual([
+        { channel: "email", strategy: "password" },
+      ]);
     });
 
     it("Should set reason to 'protocol' when setMode() returns 'test'", async () => {
@@ -132,10 +144,12 @@ describe("Mode tests", () => {
         status: 200,
         data: {
           mode: "test",
-          firstFactors: [{ channel: "email", strategy: "password" }],
-          secondFactors: [],
-          isMfaRequired: false,
-          isEnabled: true
+          authentication: {
+            firstFactors: [{ channel: "email", strategy: "password" }],
+            secondFactors: [],
+            isMfaRequired: false,
+            isEnabled: true,
+          },
         },
       });
 
@@ -145,9 +159,11 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("test");
       expect(Userfront.mode.value).toEqual("test");
       expect(Userfront.mode.reason).toEqual("protocol");
-      expect(mfaData.firstFactors).toEqual([{ channel: "email", strategy: "password" }]);
+      expect(authenticationData.firstFactors).toEqual([
+        { channel: "email", strategy: "password" },
+      ]);
     });
-    
+
     it("Should not fail if a default auth flow is not present", async () => {
       window.location = new URL("https://example.com/login");
 
@@ -156,7 +172,7 @@ describe("Mode tests", () => {
       api.get.mockResolvedValue({
         status: 200,
         data: {
-          mode: "live"
+          mode: "live",
         },
       });
 
@@ -166,8 +182,8 @@ describe("Mode tests", () => {
       expect(Userfront.store.mode).toEqual("live");
       expect(Userfront.mode.value).toEqual("live");
       expect(Userfront.mode.reason).toEqual("domain");
-      expect(mfaData.firstFactors).toEqual([]);
-    })
+      expect(authenticationData.firstFactors).toEqual([]);
+    });
   });
 });
 

--- a/test/password.spec.js
+++ b/test/password.spec.js
@@ -1,11 +1,20 @@
 import Userfront from "../src/index.js";
 import api from "../src/api.js";
+import { unsetUser } from "../src/user.js";
 import {
   createAccessToken,
   createIdToken,
   createRefreshToken,
   idTokenUserDefaults,
+  createMfaRequiredResponse,
+  setMfaRequired,
 } from "./config/utils.js";
+import {
+  assertMfaStateMatches,
+  assertNoUser,
+  mfaHeaders,
+  noMfaHeaders
+} from "./config/assertions.js";
 import { exchange } from "../src/refresh.js";
 import { signupWithPassword, loginWithPassword } from "../src/password.js";
 import { handleRedirect } from "../src/url.js";
@@ -29,10 +38,19 @@ const mockResponse = {
   },
 };
 
+// Mock "MFA Required" API response
+const mockMfaRequiredResponse = createMfaRequiredResponse({
+  firstFactor: {
+    strategy: "password",
+    channel: "email"
+  }
+});
+
 describe("signupWithPassword()", () => {
   beforeEach(() => {
     Userfront.init(tenantId);
     jest.resetAllMocks();
+    unsetUser();
   });
 
   it("should send a request, set access and ID cookies, and initiate nonce exchange", async () => {
@@ -55,7 +73,7 @@ describe("signupWithPassword()", () => {
       name: payload.name,
       data: payload.userData,
       password: payload.password,
-    });
+    }, noMfaHeaders);
 
     // Should have called exchange() with the API's response
     expect(exchange).toHaveBeenCalledWith(mockResponse.data);
@@ -91,7 +109,7 @@ describe("signupWithPassword()", () => {
       tenantId,
       email: payload.email,
       password: payload.password,
-    });
+    }, noMfaHeaders);
 
     // Should have called exchange() with the API's response
     expect(exchange).toHaveBeenCalledWith(mockResponse.data);
@@ -136,7 +154,7 @@ describe("signupWithPassword()", () => {
     expect(api.post).toHaveBeenCalledWith(`/auth/create`, {
       tenantId,
       ...payload,
-    });
+    }, noMfaHeaders);
 
     // Should have called exchange() with the API's response
     expect(exchange).toHaveBeenCalledWith(mockResponseCopy.data);
@@ -171,12 +189,59 @@ describe("signupWithPassword()", () => {
       })
     ).rejects.toEqual(new Error(mockResponse.response.data.message));
   });
+
+  it("should handle an MFA Required response", async () => {
+    // Return an MFA Required response
+    api.post.mockImplementationOnce(() => mockMfaRequiredResponse);
+
+    const payload = {
+      email: "email@example.com",
+      password: "something",
+    };
+    const data = await signupWithPassword(payload);
+
+    // Should have sent the correct API request
+    expect(api.post).toHaveBeenCalledWith(`/auth/create`, {
+      tenantId,
+      email: payload.email,
+      password: payload.password,
+    }, noMfaHeaders);
+
+    // Should have updated the MFA service state
+    assertMfaStateMatches(mockMfaRequiredResponse);
+
+    // Should not have set the user object or redirected
+    assertNoUser(Userfront.user);
+    expect(handleRedirect).not.toHaveBeenCalled();
+
+    // Should have returned MFA options & firstFactorToken
+    expect(data).toEqual(mockMfaRequiredResponse.data);
+  });
+
+  it("should include the firstFactorToken if this is the second factor", async () => {
+    // Set up the MFA service
+    setMfaRequired();
+    api.post.mockImplementationOnce(() => mockResponse);
+    const payload = {
+      email: "email@example.com",
+      password: "something",
+    };
+    await signupWithPassword(payload);
+
+    // Should have sent the correct API request, with MFA headers
+    expect(api.post).toHaveBeenCalledWith(`/auth/create`, {
+      tenantId,
+      email: payload.email,
+      password: payload.password,
+    }, mfaHeaders);
+  });
 });
 
 describe("loginWithPassword()", () => {
   beforeEach(() => {
     Userfront.init(tenantId);
     jest.resetAllMocks();
+    unsetUser();
   });
 
   describe("with username & password", () => {
@@ -195,7 +260,7 @@ describe("loginWithPassword()", () => {
       expect(api.post).toHaveBeenCalledWith(`/auth/basic`, {
         tenantId,
         ...payload,
-      });
+      }, noMfaHeaders);
 
       // Should have returned the proper value
       expect(data).toEqual(mockResponse.data);
@@ -241,7 +306,7 @@ describe("loginWithPassword()", () => {
         tenantId,
         emailOrUsername: payload.email,
         password: payload.password,
-      });
+      }, noMfaHeaders);
 
       // Should have called exchange() with the API's response
       expect(exchange).toHaveBeenCalledWith(mockResponseCopy.data);
@@ -277,7 +342,7 @@ describe("loginWithPassword()", () => {
       expect(api.post).toHaveBeenCalledWith(`/auth/basic`, {
         tenantId,
         ...payload,
-      });
+      }, noMfaHeaders);
 
       // Should have called exchange() with the API's response
       expect(exchange).toHaveBeenCalledWith(mockResponse.data);
@@ -311,6 +376,52 @@ describe("loginWithPassword()", () => {
           password: "somevalidpassword",
         })
       ).rejects.toEqual(new Error(mockResponse.response.data.message));
+    });
+
+    it("should handle an MFA Required response", async () => {
+      // Return an MFA Required response
+      api.post.mockImplementationOnce(() => mockMfaRequiredResponse);
+
+      const payload = {
+        email: "email@example.com",
+        password: "something",
+      };
+      const data = await loginWithPassword(payload);
+
+      // Should have sent the correct API request
+      expect(api.post).toHaveBeenCalledWith(`/auth/basic`, {
+        tenantId,
+        emailOrUsername: payload.email,
+        password: payload.password,
+      }, noMfaHeaders);
+
+      // Should have updated the MFA service state
+      assertMfaStateMatches(mockMfaRequiredResponse);
+
+      // Should not have set the user object or redirected
+      assertNoUser(Userfront.user);
+      expect(handleRedirect).not.toHaveBeenCalled();
+
+      // Should have returned MFA options & firstFactorToken
+      expect(data).toEqual(mockMfaRequiredResponse.data);
+    });
+
+    it("should include the firstFactorToken if this is the second factor", async () => {
+      // Set up the MFA service
+      setMfaRequired();
+      api.post.mockImplementationOnce(() => mockResponse);
+      const payload = {
+        email: "email@example.com",
+        password: "something",
+      };
+      await loginWithPassword(payload);
+
+      // Should have sent the correct API request, with MFA headers
+      expect(api.post).toHaveBeenCalledWith(`/auth/basic`, {
+        tenantId,
+        emailOrUsername: payload.email,
+        password: payload.password,
+      }, mfaHeaders);
     });
   });
 });

--- a/test/saml.spec.js
+++ b/test/saml.spec.js
@@ -8,6 +8,9 @@ import {
   idTokenUserDefaults,
   mockWindow,
 } from "./config/utils.js";
+import {
+  noMfaHeaders
+} from "./config/assertions.js";
 import { login } from "../src/login.js";
 import { logout } from "../src/logout.js";
 import { unsetTokens } from "../src/tokens.js";
@@ -93,7 +96,7 @@ describe("completeSamlLogin()", () => {
     expect(api.post).toHaveBeenCalledWith(`/auth/basic`, {
       tenantId,
       ...payload,
-    });
+    }, noMfaHeaders);
 
     // Should have returned the proper value
     expect(data).toEqual(mockResponse.data);

--- a/test/session.spec.js
+++ b/test/session.spec.js
@@ -1,5 +1,6 @@
 import Cookies from "js-cookie";
 import Userfront from "../src/index.js";
+import api from "../src/api.js";
 import {
   createAccessToken,
   createIdToken,
@@ -10,10 +11,34 @@ import * as Refresh from "../src/refresh.js";
 import { store } from "../src/store.js";
 
 jest.mock("../src/refresh.js");
+jest.mock("../src/api.js");
 
 const tenantId = "abcd4321";
 const mockAccessToken = createAccessToken();
 const mockIdToken = createIdToken();
+
+const mockAuthFlow = {
+  firstFactors: [
+    {
+      channel: "email",
+      strategy: "password"
+    },
+    {
+      channel: "email",
+      strategy: "link"
+    }
+  ],
+  secondFactors: [
+    {
+      channel: "authenticator",
+      strategy: "totp"
+    },
+    {
+      channel: "sms",
+      strategy: "verificationCode"
+    }
+  ]
+}
 
 describe("Userfront session helpers", () => {
   beforeAll(() => {
@@ -23,6 +48,10 @@ describe("Userfront session helpers", () => {
     // Initialize Userfront
     Userfront.init(tenantId);
   });
+  
+  beforeEach(() => {
+    api.get.mockImplementationOnce(() => mockAuthFlow);
+  })
 
   describe("getSession()", () => {
     afterEach(() => {

--- a/test/totp.spec.js
+++ b/test/totp.spec.js
@@ -1,11 +1,20 @@
 import Userfront from "../src/index.js";
 import api from "../src/api.js";
+import { unsetUser } from "../src/user.js";
 import {
   createAccessToken,
   createIdToken,
   createRefreshToken,
   idTokenUserDefaults,
+  createMfaRequiredResponse,
+  setMfaRequired,
 } from "./config/utils.js";
+import {
+  assertMfaStateMatches,
+  assertNoUser,
+  mfaHeaders,
+  noMfaHeaders
+} from "./config/assertions.js";
 import { setCookie, removeAllCookies } from "../src/cookies.js";
 import { handleRedirect } from "../src/url.js";
 import { loginWithTotp } from "../src/totp.js";
@@ -30,9 +39,19 @@ describe("loginWithTotp()", () => {
       redirectTo: "/dashboard",
     },
   };
+
+  // Mock "MFA Required" API response
+  const mockMfaRequiredResponse = createMfaRequiredResponse({
+    firstFactor: {
+      strategy: "totp",
+      channel: "authenticator"
+    }
+  });
+
   beforeEach(() => {
     Userfront.init(tenantId);
     jest.resetAllMocks();
+    unsetUser();
   });
 
   it("should login with totpCode", async () => {
@@ -58,7 +77,7 @@ describe("loginWithTotp()", () => {
     expect(api.post).toHaveBeenCalledWith(`/auth/totp`, {
       tenantId,
       ...payload,
-    });
+    }, noMfaHeaders);
 
     // Should return the correct value
     expect(data).toEqual(mockResponseCopy.data);
@@ -100,7 +119,7 @@ describe("loginWithTotp()", () => {
     expect(api.post).toHaveBeenCalledWith(`/auth/totp`, {
       tenantId,
       ...payload,
-    });
+    }, noMfaHeaders);
 
     // Should return the correct value
     expect(data).toEqual(mockResponseCopy.data);
@@ -138,7 +157,7 @@ describe("loginWithTotp()", () => {
     expect(api.post).toHaveBeenCalledWith(`/auth/totp`, {
       tenantId,
       ...payload,
-    });
+    }, noMfaHeaders);
 
     // Should return the correct value
     expect(data).toEqual(mockResponse.data);
@@ -174,7 +193,7 @@ describe("loginWithTotp()", () => {
     expect(api.post).toHaveBeenCalledWith(`/auth/totp`, {
       tenantId,
       ...payload,
-    });
+    }, noMfaHeaders);
 
     // Should return the correct value
     expect(data).toEqual(mockResponse.data);
@@ -192,6 +211,58 @@ describe("loginWithTotp()", () => {
       data: mockResponse.data,
     });
   });
+
+  it("should handle an MFA Required response", async () => {
+    api.post.mockImplementationOnce(() => mockMfaRequiredResponse);
+
+    // Call loginWithTotp()
+    const payload = {
+      userId: 123,
+      totpCode: "123456",
+    };
+    const data = await loginWithTotp({
+      redirect: false,
+      ...payload,
+    });
+
+    // Should have sent the proper API request
+    expect(api.post).toHaveBeenCalledWith(`/auth/totp`, {
+      tenantId,
+      ...payload,
+    }, noMfaHeaders);
+
+    // Should have updated the MFA service state
+    assertMfaStateMatches(mockMfaRequiredResponse);
+
+    // Should not have set the user object or redirected
+    assertNoUser(Userfront.user);
+    expect(handleRedirect).not.toHaveBeenCalled();
+
+    // Should have returned MFA options & firstFactorToken
+    expect(data).toEqual(mockMfaRequiredResponse.data);
+  });
+
+  it("should include the firstFactorToken if this is the second factor", async () => {
+    // Set up the MFA service
+    setMfaRequired();
+    api.post.mockImplementationOnce(() => mockResponse);
+
+    // Call loginWithTotp()
+    const payload = {
+      userId: 123,
+      totpCode: "123456",
+    };
+    await loginWithTotp({
+      redirect: false,
+      ...payload,
+    });
+
+    // Should have sent the proper API request
+    expect(api.post).toHaveBeenCalledWith(`/auth/totp`, {
+      tenantId,
+      ...payload,
+    }, mfaHeaders);
+  })
 });
 
 describe("user.getTotp()", () => {
@@ -229,6 +300,22 @@ describe("user.getTotp()", () => {
 
     expect(data).toEqual(mockResponse.data);
   });
+
+  it("should request the user's TOTP information with the firstFactorToken if this is the second factor", async () => {
+    // Set up the MFA services
+    setMfaRequired();
+
+    // Mock the API response
+    api.get.mockImplementationOnce(() => mockResponse);
+
+    // Call user.getTotp()
+    const data = await Userfront.user.getTotp();
+
+    // Should have sent the proper API request
+    expect(api.get).toHaveBeenCalledWith(`/auth/totp`, mfaHeaders);
+
+    expect(data).toEqual(mockResponse.data);
+  })
 
   it("should throw an error if the user is not logged in", async () => {
     // Log the user out

--- a/test/url.spec.js
+++ b/test/url.spec.js
@@ -81,7 +81,7 @@ describe("redirectIfLoggedIn()", () => {
     expect(removeAllCookies).toHaveBeenCalledTimes(1);
 
     // Should not have made request to Userfront API or redirected the user
-    expect(api.get).not.toHaveBeenCalled();
+    expect(api.get).not.toHaveBeenCalledWith('/self');
     expect(window.location.assign).not.toHaveBeenCalled();
   });
 
@@ -123,7 +123,7 @@ describe("redirectIfLoggedIn()", () => {
 
     // Should redirected immediately without calling Userfront API
     expect(removeAllCookies).not.toHaveBeenCalled();
-    expect(api.get).not.toHaveBeenCalled();
+    expect(api.get).not.toHaveBeenCalledWith('/self');
     expect(window.location.assign).toHaveBeenCalledTimes(1);
     expect(window.location.assign).toHaveBeenCalledWith(targetPath);
 
@@ -144,7 +144,7 @@ describe("redirectIfLoggedIn()", () => {
 
     // Should redirected immediately without calling Userfront API
     expect(removeAllCookies).not.toHaveBeenCalled();
-    expect(api.get).not.toHaveBeenCalled();
+    expect(api.get).not.toHaveBeenCalledWith('/self');
     expect(window.location.assign).toHaveBeenCalledTimes(1);
     expect(window.location.assign).toHaveBeenCalledWith(targetPath);
 
@@ -216,7 +216,7 @@ describe("redirectIfLoggedOut()", () => {
     expect(removeAllCookies).toHaveBeenCalledTimes(1);
 
     // Should not have made request to Userfront API or redirected the user
-    expect(api.get).not.toHaveBeenCalled();
+    expect(api.get).not.toHaveBeenCalledWith('/self');
     expect(window.location.assign).not.toHaveBeenCalled();
   });
 
@@ -231,7 +231,7 @@ describe("redirectIfLoggedOut()", () => {
 
     // Should redirected immediately without calling Userfront API
     expect(removeAllCookies).toHaveBeenCalled();
-    expect(api.get).not.toHaveBeenCalled();
+    expect(api.get).not.toHaveBeenCalledWith('/self');
     expect(window.location.assign).toHaveBeenCalledTimes(1);
     expect(window.location.assign).toHaveBeenCalledWith(targetPath);
 
@@ -250,7 +250,7 @@ describe("redirectIfLoggedOut()", () => {
 
     // Should redirected immediately without calling Userfront API
     expect(removeAllCookies).toHaveBeenCalled();
-    expect(api.get).not.toHaveBeenCalled();
+    expect(api.get).not.toHaveBeenCalledWith('/self');
     expect(window.location.assign).toHaveBeenCalledTimes(1);
     expect(window.location.assign).toHaveBeenCalledWith(targetPath);
 


### PR DESCRIPTION
Deep
Closes #118

- Add MFA handling to all signup & login auth methods
  - When an "MFA Required" response is received, store its `firstFactorToken` and `secondFactors`. Subsequent signup or login attempts will be "second factor" attempts, with the `firstFactorToken` attached as bearer auth.
  - On successful signup or login, clear the MFA service state.
- On initialization, get the tenant's acceptable first factors from its default auth flow
  - Relevant API PR: https://github.com/userfront/api/pull/1282
- Update existing methods & unit tests to match current MFA implementation