### PR TITLE
Add MFA headers to the POST /auth/code request in sendVerificationCode

### DIFF
--- a/src/verificationCode.js
+++ b/src/verificationCode.js
@@ -59,6 +59,8 @@ export async function sendVerificationCode({
       username,
       data,
       tenantId: store.tenantId,
+    }, {
+      headers: getMfaHeaders()
     });
     return res;
   } catch (error) {

--- a/test/verificationCode.spec.js
+++ b/test/verificationCode.spec.js
@@ -62,7 +62,7 @@ describe("sendVerificationCode()", () => {
     expect(api.post).toHaveBeenCalledWith(`/auth/code`, {
       tenantId,
       ...payload,
-    });
+    }, noMfaHeaders);
 
     // Should have returned the proper value
     expect(res).toEqual(mockResponse.data);
@@ -81,7 +81,7 @@ describe("sendVerificationCode()", () => {
     expect(api.post).toHaveBeenCalledWith(`/auth/code`, {
       tenantId,
       ...payload,
-    });
+    }, noMfaHeaders);
 
     // Should have returned the proper value
     expect(data).toEqual(mockResponse.data);
@@ -121,6 +121,35 @@ describe("sendVerificationCode()", () => {
       sendVerificationCode({ channel: "email", phoneNumber: "+15558769098" })
     ).rejects.toEqual(new Error(`Email verification code requires "email"`));
   });
+
+  it("should include the firstFactorToken if this is the second factor", async () => {
+    // Set up the MFA service
+    setMfaRequired();
+
+    // Mock the API response
+    api.post.mockImplementationOnce(() => mockResponse);
+
+    const payload = {
+      channel: "sms",
+      phoneNumber: "+15558769098",
+      email: "user@example.com",
+      username: "new-by-sms",
+      name: "New User",
+      data: { attr: "custom-data" },
+    };
+
+    // Call sendVerificationCode()
+    const res = await sendVerificationCode(payload);
+
+    // Should have sent the proper API request with MFA headers
+    expect(api.post).toHaveBeenCalledWith(`/auth/code`, {
+      tenantId,
+      ...payload,
+    }, mfaHeaders);
+
+    // Should have returned the proper value
+    expect(res).toEqual(mockResponse.data);
+  })
 });
 
 describe("loginWithVerificationCode()", () => {


### PR DESCRIPTION
Glance
Closes #122

- Add MFA headers to the `POST /v0/auth/code` request sent by `sendVerificationCode`
  - (Note that `getMfaHeaders()` returns an empty object `{}` if we are not in the midst of an MFA flow.)
- Add unit test for this case
- Update existing unit tests to assert that no MFA headers are added if we are not in an MFA flow.

Oversight from the initial PR to add MFA - I had the order of operations for verification codes reversed in my mental model at that time.

MFA headers are already attached to the subsequent `PUT /v0/auth/code` request. I'm not sure if that's actually necessary, but may as well keep adding them if we have them.

When merged, should be published as `@userfront/core@0.5.0-alpha.1`.