### PR TITLE
125 & 126: noResetEmail option for password login, let server handle missing TOTP/backup codes

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -35,7 +35,6 @@ export async function login({
   phoneNumber,
   // Password
   password,
-  noResetEmail,
   // Link
   token,
   uuid,
@@ -47,6 +46,7 @@ export async function login({
   verificationCode,
   // Other
   redirect,
+  options,
 } = {}) {
   if (!method) {
     throw new Error('Userfront.login called without "method" property.');
@@ -66,7 +66,7 @@ export async function login({
         emailOrUsername,
         password,
         redirect,
-        noResetEmail
+        options,
       });
     case "passwordless":
       return sendPasswordlessLink({ email });

--- a/src/login.js
+++ b/src/login.js
@@ -35,6 +35,7 @@ export async function login({
   phoneNumber,
   // Password
   password,
+  noResetEmail,
   // Link
   token,
   uuid,
@@ -65,6 +66,7 @@ export async function login({
         emailOrUsername,
         password,
         redirect,
+        noResetEmail
       });
     case "passwordless":
       return sendPasswordlessLink({ email });

--- a/src/password.js
+++ b/src/password.js
@@ -63,7 +63,18 @@ export async function signupWithPassword({
 /**
  * Log a user in with email/username and password.
  * Redirect the browser after successful login based on the redirectTo value returned.
- * @param {Object} options
+ * @param {Object} params
+ * @param {string} params.email The user's email. One of email/username/emailOrUsername should be present.
+ * @param {string} params.username The user's username. One of email/username/emailOrUsername should be present.
+ * @param {string} params.emailOrUsername Either the user's email or username. One of email/username/emailOrUsername should be present.
+ * @param {string} params.password
+ * @param {string | boolean} params.redirect 
+ *  URL to redirect to after login, or false to suppress redirect. Otherwise, redirects to the after-login path set on the server.
+ * @param {object} params.options
+ * @param {boolean} params.options.noResetEmail
+ *  By default, Userfront sends a password reset email if a user without a password tries to log in with a password.
+ *  Set options.noResetEmail = true to override this behavior and return an error instead.
+ * 
  */
 export async function loginWithPassword({
   email,

--- a/src/password.js
+++ b/src/password.js
@@ -71,15 +71,22 @@ export async function loginWithPassword({
   emailOrUsername,
   password,
   redirect,
+  options
 }) {
   try {
+    const body = {
+      tenantId: store.tenantId,
+      emailOrUsername: email || username || emailOrUsername,
+      password,
+    };
+    if (options && options.noResetEmail) {
+      body.options = {
+        noResetEmail: true
+      }
+    }
     const { data } = await post(
       `/auth/basic`,
-      {
-        tenantId: store.tenantId,
-        emailOrUsername: email || username || emailOrUsername,
-        password,
-      },
+      body,
       {
         headers: getMfaHeaders(),
       }

--- a/src/totp.js
+++ b/src/totp.js
@@ -37,7 +37,6 @@ export async function loginWithTotp({
   redirect,
 } = {}) {
   try {
-    if (!totpCode && !backupCode) return;
 
     const { data } = await post(
       `/auth/totp`,

--- a/test/login.spec.js
+++ b/test/login.spec.js
@@ -42,7 +42,7 @@ describe("login()", () => {
         { username: "user-name", password },
         { emailOrUsername: email, password },
         { email, password, redirect: "/custom" },
-        { email, password, redirect: false },
+        { email, password, redirect: false, options: { noResetEmail: true } },
       ];
 
       // Test login for each combo

--- a/test/password.spec.js
+++ b/test/password.spec.js
@@ -390,6 +390,34 @@ describe("loginWithPassword()", () => {
       });
     });
 
+    it("should set the noResetEmail option if provided", async () => {
+      // Mock the API response
+      api.post.mockImplementationOnce(() => mockResponse);
+
+      // Call loginWithPassword()
+      const payload = {
+        emailOrUsername: idTokenUserDefaults.email,
+        password: "something",
+        options: {
+          noResetEmail: true
+        }
+      };
+      await loginWithPassword(payload);
+
+      // Should have sent the proper API request
+      expect(api.post).toHaveBeenCalledWith(
+        `/auth/basic`,
+        {
+          tenantId,
+          ...payload,
+          options: {
+            noResetEmail: true
+          }
+        },
+        noMfaHeaders
+      );
+    })
+
     it("should respond with whatever error the server sends", async () => {
       // Mock the API response
       const mockResponse = {

--- a/test/password.spec.js
+++ b/test/password.spec.js
@@ -399,8 +399,8 @@ describe("loginWithPassword()", () => {
         emailOrUsername: idTokenUserDefaults.email,
         password: "something",
         options: {
-          noResetEmail: true
-        }
+          noResetEmail: true,
+        },
       };
       await loginWithPassword(payload);
 
@@ -411,12 +411,12 @@ describe("loginWithPassword()", () => {
           tenantId,
           ...payload,
           options: {
-            noResetEmail: true
-          }
+            noResetEmail: true,
+          },
         },
         noMfaHeaders
       );
-    })
+    });
 
     it("should respond with whatever error the server sends", async () => {
       // Mock the API response

--- a/ts/index.d.ts
+++ b/ts/index.d.ts
@@ -183,6 +183,7 @@ export declare function login({
   channel,
   // Other
   redirect,
+  options,
 }: {
   method: string;
   userId?: number;
@@ -199,6 +200,7 @@ export declare function login({
   verificationCode?: string;
   channel?: "sms" | "email";
   redirect?: string | boolean;
+  options?: object;
 }): Promise<LoginResponse>;
 
 // logout()


### PR DESCRIPTION
Normal
Closes #125 
Closes #126 

- Remove client-side check that either `totpCode` or `backupCode` is present for TOTP auth, to match other methods & let the server handle this error
- Pass through `options: { noResetEmail: true }` for password logins 