### PR TITLE
130 Don't redirect logged-in user when PKCE is in use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/url.js
+++ b/src/url.js
@@ -44,7 +44,7 @@ export async function redirectIfLoggedIn({ redirect } = {}) {
     return removeAllCookies();
   }
 
-  // TODO: can handle this more elegantly once we have an exchange tokens -> authorizationCode
+  // TODO see #130: can handle this more elegantly once we have an exchange tokens -> authorizationCode
   // endpoint on the server.
   // If this is a PKCE auth session, don't redirect with this function ever.
   // The only way to get an authorizationCode currently is to go through an auth flow.

--- a/src/url.js
+++ b/src/url.js
@@ -2,6 +2,7 @@ import { get } from "./api.js";
 import { store } from "./store.js";
 import { removeAllCookies } from "./cookies.js";
 import { getSession } from "./session.js";
+import { store as pkceStore } from "./pkce.js";
 
 /**
  * Get the value of a query attribute, e.g. ?attr=value
@@ -41,6 +42,15 @@ export async function redirectIfLoggedIn({ redirect } = {}) {
   const { isLoggedIn } = await getSession();
   if (!isLoggedIn) {
     return removeAllCookies();
+  }
+
+  // TODO: can handle this more elegantly once we have an exchange tokens -> authorizationCode
+  // endpoint on the server.
+  // If this is a PKCE auth session, don't redirect with this function ever.
+  // The only way to get an authorizationCode currently is to go through an auth flow.
+  // The PKCE module handles redirect after a PKCE Required response is received.
+  if (pkceStore.usePkce) {
+    return;
   }
 
   // Redirect to a provided path (check options first, then url querystring)

--- a/test/url.spec.js
+++ b/test/url.spec.js
@@ -195,7 +195,7 @@ describe("redirectIfLoggedIn()", () => {
     api.get.mockReset();
   });
 
-  // TODO change this test when we're able to use tokens to get an authorization code
+  // TODO see #130: change this test when we're able to use tokens to get an authorization code
   it("should not redirect if PKCE is in use", async () => {
     Cookies.set(`access.${tenantId}`, mockAccessToken, {});
     store.tokens.accessToken = mockAccessToken;

--- a/test/url.spec.js
+++ b/test/url.spec.js
@@ -6,6 +6,7 @@ import { removeAllCookies } from "../src/cookies.js";
 import { store } from "../src/store.js";
 import { handleRedirect } from "../src/url.js";
 import { createAccessToken, mockWindow } from "./config/utils.js";
+import { store as pkceStore } from "../src/pkce.js";
 
 jest.mock("../src/api.js");
 jest.mock("../src/cookies.js");
@@ -193,6 +194,23 @@ describe("redirectIfLoggedIn()", () => {
     // Clear mock
     api.get.mockReset();
   });
+
+  // TODO change this test when we're able to use tokens to get an authorization code
+  it("should not redirect if PKCE is in use", async () => {
+    Cookies.set(`access.${tenantId}`, mockAccessToken, {});
+    store.tokens.accessToken = mockAccessToken;
+
+    // Signal that we should use PKCE for this session
+    pkceStore.codeChallenge = "use-pkce";
+
+    await Userfront.redirectIfLoggedIn();
+
+    pkceStore.codeChallenge = "";
+
+    // Should not have made request to Userfront API or redirected the user
+    expect(api.get).not.toHaveBeenCalledWith('/self');
+    expect(window.location.assign).not.toHaveBeenCalled();
+  })
 });
 
 describe("redirectIfLoggedOut()", () => {


### PR DESCRIPTION
Normal
Closes #130

If the user is already logged in on their mobile browser, they can potentially be auto-redirected to the after-login path when the page loads. This prevents going through the PKCE flow and redirecting back to the app with an authorization code - the user would need to log out of the browser first, which is not ideal.

To prevent this from happening, we short-circuit any attempt to use `redirectIfLoggedIn` to redirect if PKCE is in use (a challenge code query parameter is set), so the user will always go through the auth flow, receive an authorization code, and redirect back to the mobile app.