### PR TITLE
Change target to Node 12 for now, as AnyMod mods are still on it

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,7 +19,7 @@ switch (process.env.COMPAT) {
   // Otherwise:
   // - set preset-env target to modern environments
   default: {
-    config.presets.push(["@babel/preset-env", { targets: { node: "current" } }]);
+    config.presets.push(["@babel/preset-env", { targets: { node: "12" } }]);
     break;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",


### PR DESCRIPTION
Glance

Downgrade the default build to Node 12 compatibility, so Babel compiles away optional chaining.

I'd like to bump this back up to "modern" later to minimize bundle size. Node 12 reached EOL last year.