### PR TITLE
Fix Userfront.init() in Node/SSR environments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ import "./user.methods.js";
 import { refresh } from "./refresh.js";
 import { apiUrl } from "./constants.js";
 import { resetMfa } from "./authentication.js";
-import { setupPkce } from "./pkce.js"; 
 
 let initCallbacks = [];
 
@@ -57,8 +56,6 @@ function init(tenantId, opts = {}) {
   setModeSync();
 
   resetMfa();
-
-  setupPkce();
 
   try {
     if (initCallbacks.length > 0) {

--- a/src/login.js
+++ b/src/login.js
@@ -4,6 +4,7 @@ import { signonWithSso } from "./sso.js";
 import { loginWithTotp } from "./totp.js";
 import { loginWithVerificationCode } from "./verificationCode.js";
 import { completeSamlLogin } from "./saml.js";
+import { setupPkce } from "./pkce.js";
 
 /**
  * Log a user in via the provided method. This method serves to call other
@@ -51,6 +52,7 @@ export async function login({
   if (!method) {
     throw new Error('Userfront.login called without "method" property.');
   }
+  setupPkce();
   switch (method) {
     case "apple":
     case "azure":

--- a/src/pkce.js
+++ b/src/pkce.js
@@ -1,4 +1,5 @@
 import { getQueryAttr } from "./url.js";
+import { isBrowser } from "./utils.js";
 
 export const store = {
   codeChallenge: "",
@@ -12,6 +13,9 @@ export const store = {
  * @returns {string?} the challenge code, if an unexpired one is in local storage
  */
 export function readPkceDataFromLocalStorage() {
+  if (!isBrowser()) {
+    return;
+  }
   const codeChallenge = window.localStorage.getItem("uf_pkce_code_challenge");
   if (codeChallenge) {
     const expiresAt = window.localStorage.getItem("uf_pkce_code_challenge_expiresAt");
@@ -27,6 +31,9 @@ export function readPkceDataFromLocalStorage() {
  * @returns 
  */
 export function writePkceDataToLocalStorage(codeChallenge) {
+  if (!isBrowser()) {
+    return;
+  }
   if (!codeChallenge) {
     return clearPkceDataFromLocalStorage();
   }
@@ -44,6 +51,9 @@ export function writePkceDataToLocalStorage(codeChallenge) {
  * Clear the challenge code and expiration from local storage
  */
 export function clearPkceDataFromLocalStorage() {
+  if (!isBrowser()) {
+    return;
+  }
   window.localStorage.removeItem("uf_pkce_code_challenge");
   window.localStorage.removeItem("uf_pkce_code_challenge_expiresAt");
 }
@@ -55,6 +65,9 @@ export function clearPkceDataFromLocalStorage() {
  * @returns {Boolean} true if we should use PKCE in our auth requests
  */
 export function setupPkce() {
+  if (!isBrowser()) {
+    return;
+  }
   const codeChallengeFromQueryParams = getQueryAttr("code_challenge");
   if (codeChallengeFromQueryParams) {
     store.codeChallenge = codeChallengeFromQueryParams;

--- a/src/signup.js
+++ b/src/signup.js
@@ -2,6 +2,7 @@ import { signupWithPassword } from "./password.js";
 import { signonWithSso } from "./sso.js";
 import { sendPasswordlessLink } from "./link.js";
 import { sendVerificationCode } from "./verificationCode.js";
+import { setupPkce } from "./pkce.js";
 
 /**
  * Register a user via the provided method. This method serves to call other
@@ -27,6 +28,7 @@ export async function signup({
   channel,
   redirect,
 } = {}) {
+  setupPkce();
   if (!method) {
     throw new Error('Userfront.signup called without "method" property.');
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,3 +52,7 @@ export function throwFormattedError(error) {
   }
   throw error;
 }
+
+export function isBrowser() {
+  return typeof window !== "undefined";
+}

--- a/test/init-ssr.spec.js
+++ b/test/init-ssr.spec.js
@@ -2,6 +2,15 @@
  * @jest-environment node
  */
 
+/*
+ * Tests for Userfront.init() in a Node environment, simulating server-side rendering with NextJS.
+ * This is *mostly* intended as a smoke test, to make sure changes don't break NextJS compatibility.
+ * New tests should always go in init.spec.js, and may be duplicated here. Some tests don't make
+ * sense for the Node environment, so they're not present here.
+ * 
+ * Reference on Jest environment overrides: https://jestjs.io/docs/configuration#testenvironment-string
+ */
+
 import axios from "axios";
 import {
   createAccessToken,

--- a/test/init-ssr.spec.js
+++ b/test/init-ssr.spec.js
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment node
+ */
+
+import axios from "axios";
+import {
+  createAccessToken,
+  createIdToken,
+  resetStore,
+} from "./config/utils.js";
+import { noMfaHeaders } from "./config/assertions.js";
+import Userfront from "../src/index.js";
+import { setMode } from "../src/mode.js";
+import { store } from "../src/store.js";
+import { apiUrl } from "../src/constants.js";
+
+const tenantId = "abcd5432";
+const domain = "com.example.myapp";
+
+jest.mock("axios");
+
+describe("init() method in Node/SSR environment (should not crash)", () => {
+  describe("init() method with domain option", () => {
+    beforeEach(() => {
+      // Mock the axios POST response (used for signup & login)
+      const mockAccessToken = createAccessToken();
+      const mockIdToken = createIdToken();
+      axios.post.mockResolvedValue({
+        status: 200,
+        data: {
+          tokens: {
+            access: {
+              value: mockAccessToken,
+              secure: true,
+              sameSite: "Lax",
+              expires: 30,
+            },
+            id: {
+              value: mockIdToken,
+              secure: true,
+              sameSite: "Lax",
+              expires: 30,
+            },
+          },
+        },
+      });
+    });
+
+    afterEach(() => {
+      resetStore(Userfront);
+      jest.resetAllMocks();
+    });
+
+    it("should include the x-application-id and x-origin headers for mode", async () => {
+      store.mode = "test";
+      Userfront.init(tenantId, { domain });
+
+      axios.get.mockResolvedValue({
+        status: 200,
+        data: {
+          mode: "live",
+          authentication: {
+            firstFactors: [],
+            secondFactors: [],
+            isMfaRequired: false,
+            isEnabled: false,
+          },
+        },
+      });
+      await setMode();
+
+      const url = `https://${domain}`;
+
+      expect(axios.defaults.headers.common["x-application-id"]).toEqual(url);
+      expect(axios.defaults.headers.common["x-origin"]).toEqual(url);
+      expect(axios.get).toHaveBeenCalledWith(
+        `https://api.userfront.com/v0/tenants/${tenantId}/mode`,
+        undefined
+      );
+      expect(store.mode).toEqual("live");
+    });
+
+    it("should include the x-application-id and x-origin headers for signup", async () => {
+      Userfront.init(tenantId, { domain });
+
+      const email = "user@example.com";
+      const password = "foobar";
+
+      await Userfront.signup({ method: "password", email, password });
+
+      const url = `https://${domain}`;
+
+      expect(axios.defaults.headers.common["x-application-id"]).toEqual(url);
+      expect(axios.defaults.headers.common["x-origin"]).toEqual(url);
+      expect(axios.post).toHaveBeenCalledWith(
+        "https://api.userfront.com/v0/auth/create",
+        {
+          email,
+          password,
+          username: undefined,
+          name: undefined,
+          data: undefined,
+          tenantId,
+        },
+        noMfaHeaders
+      );
+    });
+
+    it("should include the x-application-id and x-origin headers for login", async () => {
+      Userfront.init(tenantId, { domain });
+
+      const email = "user@example.com";
+      const password = "foobar";
+
+      await Userfront.login({ method: "password", email, password });
+
+      const url = `https://${domain}`;
+
+      expect(axios.defaults.headers.common["x-application-id"]).toEqual(url);
+      expect(axios.defaults.headers.common["x-origin"]).toEqual(url);
+
+      expect(axios.post).toHaveBeenCalledWith(
+        "https://api.userfront.com/v0/auth/basic",
+        {
+          emailOrUsername: email,
+          password,
+          tenantId,
+        },
+        noMfaHeaders
+      );
+    });
+  });
+
+  describe("init() method with baseUrl option", () => {
+    it("should add baseUrl to store when provided", async () => {
+      const baseUrl = "https://custom.example.com/api/v1/";
+
+      Userfront.init(tenantId, { baseUrl });
+
+      expect(store.baseUrl).toEqual(baseUrl);
+    });
+
+    it("should default baseUrl to 'https://api.userfront.com/v0' if empty or not provided", async () => {
+      // Modify baseUrl to be sure it's changed again in `init`
+      store.baseUrl = "https://example.com";
+      Userfront.init(tenantId, { baseUrl: "" });
+      expect(store.baseUrl).toEqual(apiUrl);
+
+      store.baseUrl = "https://example.com";
+      Userfront.init(tenantId);
+      expect(store.baseUrl).toEqual(apiUrl);
+    });
+
+    it("should support a baseUrl with trailing slash", async () => {
+      const customBaseUrl = "https://custom.example.com/";
+
+      Userfront.init(tenantId, {
+        baseUrl: customBaseUrl,
+      });
+      expect(store.baseUrl).toEqual(customBaseUrl);
+
+      store.tokens.accessToken = "foobar";
+      await Userfront.logout();
+
+      expect(axios.get).toHaveBeenCalledWith(`${customBaseUrl}auth/logout`, {
+        headers: {
+          authorization: `Bearer foobar`,
+        },
+      });
+    });
+
+    it("should support a baseUrl without trailing slash", async () => {
+      const customBaseUrl = "https://custom.example.com";
+
+      Userfront.init(tenantId, {
+        baseUrl: customBaseUrl,
+      });
+      // Check trailing slash was appended
+      expect(store.baseUrl).toEqual(customBaseUrl + "/");
+
+      store.tokens.accessToken = "foobar";
+      await Userfront.logout();
+
+      // Check trailing slash is included when used in request
+      expect(axios.get).toHaveBeenCalledWith(`${customBaseUrl}/auth/logout`, {
+        headers: {
+          authorization: `Bearer foobar`,
+        },
+      });
+    });
+  });
+})


### PR DESCRIPTION
Normal
Closes #133

Defer setting up PKCE to when login or signup is called, to ensure it's run in the same environment that the login/signup request runs in. Add tests for Userfront.init in the Node jest-environment.

The PKCE service uses `window.localStorage`, which fails on the server where there is no `window` object. To make sure the PKCE service is fully set up, now we defer running it to when `login()` or `signup()` are called, so it's run in the same environment - presumably the browser, where it'll have access to local storage. (The PKCE flow doesn't make much sense for server-to-server auth, so I expect it'll always run in the browser.)