### PR TITLE
Add password-migrate login method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.4.7",
+  "version": "0.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.4.7",
+      "version": "0.5.3",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/login.js
+++ b/src/login.js
@@ -1,4 +1,5 @@
 import { loginWithPassword } from "./password.js";
+import { loginWithPasswordMigrate } from "./password.migrate.js";
 import { loginWithLink, sendPasswordlessLink } from "./link.js";
 import { signonWithSso } from "./sso.js";
 import { loginWithTotp } from "./totp.js";
@@ -23,7 +24,8 @@ import { setupPkce } from "./pkce.js";
  * @param {String} backupCode
  * @param {String} channel "sms" or "email"
  * @param {String} verificationCode
- * @param {String} redirect - do not redirect if false, or redirect to given path
+ * @param {String | Boolean} redirect - do not redirect if false, or redirect to given path
+ * @param {Function} handleUpstreamResponse
  */
 export async function login({
   method,
@@ -47,6 +49,7 @@ export async function login({
   verificationCode,
   // Other
   redirect,
+  handleUpstreamResponse,
   options,
 } = {}) {
   if (!method) {
@@ -68,6 +71,16 @@ export async function login({
         emailOrUsername,
         password,
         redirect,
+        options,
+      });
+    case "password-migrate":
+      return loginWithPasswordMigrate({
+        email,
+        username,
+        emailOrUsername,
+        password,
+        redirect,
+        handleUpstreamResponse,
         options,
       });
     case "passwordless":

--- a/src/password.migrate.js
+++ b/src/password.migrate.js
@@ -1,0 +1,79 @@
+import { post } from "./api.js";
+import { setCookiesAndTokens } from "./cookies.js";
+import { store } from "./store.js";
+import { handleRedirect } from "./url.js";
+import { throwFormattedError } from "./utils.js";
+import { exchange } from "./refresh.js";
+import { getMfaHeaders, handleMfaRequired } from "./authentication.js";
+import { getPkceRequestQueryParams, redirectWithPkce } from "./pkce.js";
+
+/**
+ * Log a user in with email/username and password using the password/migrate endpoint.
+ * Redirect the browser after successful login based on the redirectTo value returned.
+ * @param {Object} params
+ * @param {string} params.email The user's email. One of email/username/emailOrUsername should be present.
+ * @param {string} params.username The user's username. One of email/username/emailOrUsername should be present.
+ * @param {string} params.emailOrUsername Either the user's email or username. One of email/username/emailOrUsername should be present.
+ * @param {string} params.password
+ * @param {string | boolean} params.redirect
+ *  URL to redirect to after login, or false to suppress redirect. Otherwise, redirects to the after-login path set on the server.
+ * @param {function} params.handleUpstreamResponse Function to run after receiving response, but before redirection
+ * @param {object} params.options
+ * @param {boolean} params.options.noResetEmail
+ *  By default, Userfront sends a password reset email if a user without a password tries to log in with a password.
+ *  Set options.noResetEmail = true to override this behavior and return an error instead.
+ *
+ */
+export async function loginWithPasswordMigrate({
+  email,
+  username,
+  emailOrUsername,
+  password,
+  redirect,
+  handleUpstreamResponse,
+  options,
+}) {
+  try {
+    const body = {
+      tenantId: store.tenantId,
+      emailOrUsername: email || username || emailOrUsername,
+      password,
+    };
+    if (options && options.noResetEmail) {
+      body.options = {
+        noResetEmail: true,
+      };
+    }
+
+    // Make the request to password/migrate
+    const { data } = await post(`/auth/password/migrate`, body, {
+      headers: getMfaHeaders(),
+      params: getPkceRequestQueryParams(),
+    });
+
+    if (typeof handleUpstreamResponse === "function") {
+      await handleUpstreamResponse(data.upstreamResponse);
+    }
+
+    if (data.hasOwnProperty("tokens")) {
+      setCookiesAndTokens(data.tokens);
+      await exchange(data);
+      handleRedirect({ redirect, data });
+      return data;
+    }
+
+    if (data.authorizationCode) {
+      const url = redirect || data.redirectTo;
+      if (url) {
+        redirectWithPkce(url, data.authorizationCode);
+        return;
+      } else {
+        // TODO this is neither valid nor invalid
+      }
+    }
+
+    throw new Error("Please try again.");
+  } catch (error) {
+    throwFormattedError(error);
+  }
+}

--- a/test/login.spec.js
+++ b/test/login.spec.js
@@ -2,6 +2,7 @@ import Userfront from "../src/index.js";
 
 import { login } from "../src/login.js";
 import { loginWithPassword } from "../src/password.js";
+import { loginWithPasswordMigrate } from "../src/password.migrate.js";
 import { sendPasswordlessLink, loginWithLink } from "../src/link.js";
 import { signonWithSso } from "../src/sso.js";
 import { loginWithTotp } from "../src/totp.js";
@@ -11,6 +12,7 @@ import { handleRedirect } from "../src/url.js";
 
 // Mock all methods to be called
 jest.mock("../src/password.js");
+jest.mock("../src/password.migrate.js");
 jest.mock("../src/link.js");
 jest.mock("../src/sso.js");
 jest.mock("../src/totp.js");
@@ -52,6 +54,29 @@ describe("login()", () => {
 
         // Assert that loginWithPassword was called correctly
         expect(loginWithPassword).toHaveBeenCalledWith(combo);
+      });
+    });
+  });
+
+  describe(`{ method: "password-migrate" }`, () => {
+    it(`should call loginWithPasswordMigrate()`, () => {
+      const email = "user@example.com";
+      const password = "some-password123";
+      const combos = [
+        { email, password },
+        { username: "user-name", password },
+        { emailOrUsername: email, password },
+        { email, password, redirect: "/custom" },
+        { email, password, redirect: false, options: { noResetEmail: true } },
+      ];
+
+      // Test login for each combo
+      combos.forEach((combo) => {
+        // Call login for the combo
+        Userfront.login({ method: "password-migrate", ...combo });
+
+        // Assert that loginWithPassword was called correctly
+        expect(loginWithPasswordMigrate).toHaveBeenCalledWith(combo);
       });
     });
   });

--- a/test/login.spec.js
+++ b/test/login.spec.js
@@ -62,9 +62,11 @@ describe("login()", () => {
     it(`should call loginWithPasswordMigrate()`, () => {
       const email = "user@example.com";
       const password = "some-password123";
+      const handleFn = jest.fn();
       const combos = [
         { email, password },
         { username: "user-name", password },
+        { username: "user-name", password, handleUpstreamResponse: handleFn },
         { emailOrUsername: email, password },
         { email, password, redirect: "/custom" },
         { email, password, redirect: false, options: { noResetEmail: true } },

--- a/test/password-migrate.spec.js
+++ b/test/password-migrate.spec.js
@@ -1,0 +1,274 @@
+import Userfront from "../src/index.js";
+import api from "../src/api.js";
+import { unsetUser } from "../src/user.js";
+import {
+  createAccessToken,
+  createIdToken,
+  createRefreshToken,
+  idTokenUserDefaults,
+  createMfaRequiredResponse,
+  setMfaRequired,
+} from "./config/utils.js";
+import {
+  assertAuthenticationDataMatches,
+  assertNoUser,
+  mfaHeaders,
+  noMfaHeaders,
+  pkceParams,
+} from "./config/assertions.js";
+import { exchange } from "../src/refresh.js";
+import { loginWithPasswordMigrate } from "../src/password.migrate.js";
+import { handleRedirect } from "../src/url.js";
+import * as Pkce from "../src/pkce.js";
+
+jest.mock("../src/api.js");
+jest.mock("../src/refresh.js");
+jest.mock("../src/url.js");
+jest.mock("../src/pkce.js");
+
+const tenantId = "abcd9876";
+
+// Mock API response
+const mockResponse = {
+  data: {
+    tokens: {
+      access: { value: createAccessToken() },
+      id: { value: createIdToken() },
+      refresh: { value: createRefreshToken() },
+    },
+    nonce: "nonce-value",
+    redirectTo: "/dashboard",
+    upstreamResponse: {
+      arbitrary: "response",
+    },
+  },
+};
+
+describe("loginWithPasswordMigrate()", () => {
+  beforeEach(() => {
+    Userfront.init(tenantId);
+    jest.resetAllMocks();
+    unsetUser();
+  });
+
+  describe("with username & password", () => {
+    it("should send a request, set access and ID cookies, and initiate nonce exchange", async () => {
+      // Mock the API response
+      api.post.mockImplementationOnce(() => mockResponse);
+
+      // Call loginWithPasswordMigrate()
+      const payload = {
+        emailOrUsername: idTokenUserDefaults.email,
+        password: "something",
+      };
+      const data = await loginWithPasswordMigrate(payload);
+
+      // Should have sent the proper API request
+      expect(api.post).toHaveBeenCalledWith(
+        `/auth/password/migrate`,
+        {
+          tenantId,
+          ...payload,
+        },
+        noMfaHeaders
+      );
+
+      // Should have returned the proper value
+      expect(data).toEqual(mockResponse.data);
+
+      // Should have called exchange() with the API's response
+      expect(exchange).toHaveBeenCalledWith(mockResponse.data);
+
+      // Should have set the user object
+      expect(Userfront.user.email).toEqual(payload.emailOrUsername);
+      expect(Userfront.user.userId).toEqual(idTokenUserDefaults.userId);
+
+      // Should call handleRedirect correctly
+      expect(handleRedirect).toHaveBeenCalledWith({
+        redirect: payload.redirect,
+        data: mockResponse.data,
+      });
+    });
+
+    it("should call handleUpstreamResponse before redirecting", async () => {
+      // Mock the API response
+      api.post.mockImplementationOnce(() => mockResponse);
+
+      // Add a handleUpstreamResponse method
+      const handleFn = jest.fn();
+
+      // Call loginWithPasswordMigrate()
+      const payload = {
+        emailOrUsername: idTokenUserDefaults.email,
+        password: "something",
+        handleUpstreamResponse: handleFn,
+      };
+      const data = await loginWithPasswordMigrate(payload);
+
+      // Should have sent the proper API request
+      expect(api.post).toHaveBeenCalledWith(
+        `/auth/password/migrate`,
+        {
+          tenantId,
+          emailOrUsername: payload.emailOrUsername,
+          password: payload.password,
+        },
+        noMfaHeaders
+      );
+
+      // Should have returned the proper value
+      expect(data).toEqual(mockResponse.data);
+
+      // Should have called exchange() with the API's response
+      expect(exchange).toHaveBeenCalledWith(mockResponse.data);
+
+      // Should have called handleFn with the upstreamResponse
+      expect(handleFn).toHaveBeenCalledWith(mockResponse.data.upstreamResponse);
+
+      // Should have set the user object
+      expect(Userfront.user.email).toEqual(payload.emailOrUsername);
+      expect(Userfront.user.userId).toEqual(idTokenUserDefaults.userId);
+
+      // Should call handleRedirect correctly
+      expect(handleRedirect).toHaveBeenCalledWith({
+        redirect: payload.redirect,
+        data: mockResponse.data,
+      });
+    });
+
+    it("should login and not redirect if redirect = false", async () => {
+      // Update the userId to ensure it is overwritten
+      const newAttrs = {
+        userId: 1009,
+        email: "someone-else@example.com",
+      };
+      const mockResponseCopy = JSON.parse(JSON.stringify(mockResponse));
+      mockResponseCopy.data.tokens.id.value = createIdToken(newAttrs);
+
+      // Mock the API response
+      api.post.mockImplementationOnce(() => mockResponseCopy);
+
+      // Call loginWithPasswordMigrate() with redirect = false
+      const payload = {
+        email: newAttrs.email,
+        password: "something",
+      };
+      const data = await loginWithPasswordMigrate({
+        redirect: false,
+        ...payload,
+      });
+
+      // Should have sent the proper API request
+      expect(api.post).toHaveBeenCalledWith(
+        `/auth/password/migrate`,
+        {
+          tenantId,
+          emailOrUsername: payload.email,
+          password: payload.password,
+        },
+        noMfaHeaders
+      );
+
+      // Should have called exchange() with the API's response
+      expect(exchange).toHaveBeenCalledWith(mockResponseCopy.data);
+
+      // Should have returned the proper value
+      expect(data).toEqual(mockResponseCopy.data);
+
+      // Should have set the user object
+      expect(Userfront.user.email).toEqual(payload.email);
+      expect(Userfront.user.userId).toEqual(newAttrs.userId);
+
+      // Should call handleRedirect correctly
+      expect(handleRedirect).toHaveBeenCalledWith({
+        redirect: false,
+        data: mockResponseCopy.data,
+      });
+    });
+
+    it("should login and redirect to a provided path", async () => {
+      api.post.mockImplementationOnce(() => mockResponse);
+
+      // Call loginWithPasswordMigrate() with redirect = false
+      const payload = {
+        emailOrUsername: idTokenUserDefaults.email,
+        password: "something",
+      };
+      await loginWithPasswordMigrate({
+        redirect: false,
+        ...payload,
+      });
+
+      // Should have sent the proper API request
+      expect(api.post).toHaveBeenCalledWith(
+        `/auth/password/migrate`,
+        {
+          tenantId,
+          ...payload,
+        },
+        noMfaHeaders
+      );
+
+      // Should have called exchange() with the API's response
+      expect(exchange).toHaveBeenCalledWith(mockResponse.data);
+
+      // Should have set the user object
+      expect(Userfront.user.email).toEqual(payload.emailOrUsername);
+      expect(Userfront.user.userId).toEqual(idTokenUserDefaults.userId);
+
+      // Should call handleRedirect correctly
+      expect(handleRedirect).toHaveBeenCalledWith({
+        redirect: false,
+        data: mockResponse.data,
+      });
+    });
+
+    it("should set the noResetEmail option if provided", async () => {
+      // Mock the API response
+      api.post.mockImplementationOnce(() => mockResponse);
+
+      // Call loginWithPasswordMigrate()
+      const payload = {
+        emailOrUsername: idTokenUserDefaults.email,
+        password: "something",
+        options: {
+          noResetEmail: true,
+        },
+      };
+      await loginWithPasswordMigrate(payload);
+
+      // Should have sent the proper API request
+      expect(api.post).toHaveBeenCalledWith(
+        `/auth/password/migrate`,
+        {
+          tenantId,
+          ...payload,
+          options: {
+            noResetEmail: true,
+          },
+        },
+        noMfaHeaders
+      );
+    });
+
+    it("should respond with whatever error the server sends", async () => {
+      // Mock the API response
+      const mockResponse = {
+        response: {
+          data: {
+            error: "Bad Request",
+            message: `That's a dumb email address.`,
+            statusCode: 400,
+          },
+        },
+      };
+      api.post.mockImplementationOnce(() => Promise.reject(mockResponse));
+      expect(
+        loginWithPasswordMigrate({
+          email: "valid@example.com",
+          password: "somevalidpassword",
+        })
+      ).rejects.toEqual(new Error(mockResponse.response.data.message));
+    });
+  });
+});


### PR DESCRIPTION
Normal
Closes #136 

- Adds the `password-migrate` login method
  - Includes a `handleUpstreamResponse` handler that runs before redirection, so that details from the upstreamResponse can be injected into local libraries as needed.

The `password-migrate` login method largely mirrors the `password` login method, with the exception of:
- A different endpoint
- Addition of the `handleUpstreamResponse` option. This naming matches the `handleRedirect` and `handleError` methods proposed for all login/signup methods in https://github.com/userfront/userfront-core/issues/101.