### PR TITLE
With `redirect: true`, do not redirect to "/true"

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -30,6 +30,12 @@ export function getQueryAttr(attrName) {
  */
 export const handleRedirect = ({ redirect, data }) => {
   if (redirect === false) return;
+  // If redirect is the boolean true, redirect to the default redirect path, not to "/true"
+  if (redirect === true) {
+    const path = getQueryAttr("redirect") || data.redirectTo || "/";
+    redirectToPath(path);
+    return;
+  }
   const path = redirect || getQueryAttr("redirect") || data.redirectTo || "/";
   redirectToPath(path);
 };

--- a/test/url.spec.js
+++ b/test/url.spec.js
@@ -58,6 +58,29 @@ describe("handleRedirect()", () => {
     handleRedirect({ redirect: false, data });
     expect(window.location.assign).not.toHaveBeenCalled();
   });
+
+  describe("with redirect=true", () => {
+    it("should redirect based on URL querystring ?redirect", () => {
+      // Add data.redirectTo to ensure it is not used
+      const data = { redirectTo: "/api-response" };
+      // Call handleRedirect()
+      window.location.href = "https://example.com/login?redirect=/url-redirect";
+      handleRedirect({ redirect: true, data });
+      expect(window.location.assign).toHaveBeenCalledWith("/url-redirect");
+    });
+
+    it("should redirect based on data.redirectTo", () => {
+      const data = { redirectTo: "/api-redirect" };
+      handleRedirect({ redirect: true, data });
+      expect(window.location.assign).toHaveBeenCalledWith(data.redirectTo);
+    });
+
+    it("should redirect to / if no other redirect is given", () => {
+      const data = { };
+      handleRedirect({ redirect: true, data });
+      expect(window.location.assign).toHaveBeenCalledWith("/");
+    });
+  });
 });
 
 describe("redirectIfLoggedIn()", () => {


### PR DESCRIPTION
Glance
Closes #138

When an auth function is called with `redirect: true`, disregard the value of `redirect` when choosing the redirect path instead of redirecting to "/true". `redirect: true` should have the same behavior as `redirect: undefined`