### PR TITLE
Allow MFA without including phoneNumber or email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.5.7",
+      "version": "0.6.1-beta.0",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.1-beta.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.6.1-beta.0",
+      "version": "0.6.1",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.1-beta.0",
+  "version": "0.6.1",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.0",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/mfa.js
+++ b/src/mfa.js
@@ -34,7 +34,7 @@ export function setFirstFactors(authentication) {
  * Check if MFA is required for the ongoing signup or login flow.
  * @returns {Boolean} true if MFA is currently required
  */
-export function isMfaRequired() {
+export function isFirstFactorTokenPresent() {
   return !!authenticationData.firstFactorToken;
 }
 
@@ -46,7 +46,7 @@ export function isMfaRequired() {
  * @param {Object} data
  */
 export function defaultHandleMfaRequired(firstFactorToken, data) {
-  if (!data.isMfaRequired) {
+  if (!data.isFirstFactorTokenPresent) {
     // If we've logged in or signed up successfully,
     // clear the MFA service state.
     if (data.message === "OK") {

--- a/src/session.js
+++ b/src/session.js
@@ -3,7 +3,7 @@ import {
   isRefreshTokenLocallyValid,
 } from "./tokens.js";
 import { authenticationData } from "./authentication.js";
-import { isMfaRequired, clearMfa } from "./mfa.js";
+import { isFirstFactorTokenPresent, clearMfa } from "./mfa.js";
 import { refresh } from "./refresh.js";
 
 /**
@@ -42,7 +42,7 @@ export async function getSession() {
   const isLoggedIn = await getIsLoggedIn();
   return {
     isLoggedIn,
-    needsSecondFactor: isMfaRequired(),
+    needsSecondFactor: isFirstFactorTokenPresent(),
     firstFactors: authenticationData.firstFactors,
     secondFactors: authenticationData.secondFactors,
     resetMfaState: clearMfa,

--- a/src/totp.js
+++ b/src/totp.js
@@ -2,7 +2,7 @@ import { get, post } from "./api.js";
 import { store } from "./store.js";
 import { throwFormattedError } from "./utils.js";
 import { handleLoginResponse } from "./authentication.js";
-import { isMfaRequired, getMfaHeaders } from "./mfa.js";
+import { isFirstFactorTokenPresent, getMfaHeaders } from "./mfa.js";
 import { getPkceRequestQueryParams } from "./pkce.js";
 
 /**
@@ -72,7 +72,7 @@ export async function loginWithTotp({
 
 export async function getTotp() {
   try {
-    if (isMfaRequired()) {
+    if (isFirstFactorTokenPresent()) {
       const { data } = await get(`/auth/totp`, {
         headers: getMfaHeaders(),
       });

--- a/test/config/utils.js
+++ b/test/config/utils.js
@@ -153,7 +153,7 @@ export function createMfaRequiredResponse({
   const response = {
     mode: mode || "live",
     message: "MFA required",
-    isMfaRequired: true,
+    isFirstFactorTokenPresent: true,
     firstFactorToken: createFirstFactorToken(),
     authentication: {
       firstFactor: _firstFactor,

--- a/test/init-ssr.spec.js
+++ b/test/init-ssr.spec.js
@@ -7,7 +7,7 @@
  * This is *mostly* intended as a smoke test, to make sure changes don't break NextJS compatibility.
  * New tests should always go in init.spec.js, and may be duplicated here. Some tests don't make
  * sense for the Node environment, so they're not present here.
- * 
+ *
  * Reference on Jest environment overrides: https://jestjs.io/docs/configuration#testenvironment-string
  */
 
@@ -71,7 +71,7 @@ describe("init() method in Node/SSR environment (should not crash)", () => {
           authentication: {
             firstFactors: [],
             secondFactors: [],
-            isMfaRequired: false,
+            isFirstFactorTokenPresent: false,
             isEnabled: false,
           },
         },
@@ -198,4 +198,4 @@ describe("init() method in Node/SSR environment (should not crash)", () => {
       });
     });
   });
-})
+});

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -58,7 +58,7 @@ describe("init() method with domain option", () => {
         authentication: {
           firstFactors: [],
           secondFactors: [],
-          isMfaRequired: false,
+          isFirstFactorTokenPresent: false,
           isEnabled: false,
         },
       },

--- a/test/mfa.spec.js
+++ b/test/mfa.spec.js
@@ -4,7 +4,7 @@ import { authenticationData } from "../src/authentication.js";
 import {
   setFirstFactors,
   defaultHandleMfaRequired,
-  isMfaRequired,
+  isFirstFactorTokenPresent,
   getMfaHeaders,
   clearMfa,
   resetMfa,
@@ -48,7 +48,7 @@ describe("MFA service", () => {
     it("should set the MFA service state if it is an MFA Required response", () => {
       const mockResponse = {
         message: "MFA required",
-        isMfaRequired: true,
+        isFirstFactorTokenPresent: true,
         firstFactorToken:
           "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a",
         authentication: {
@@ -88,7 +88,7 @@ describe("MFA service", () => {
         "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a";
       const mockResponse1 = {
         message: "MFA required",
-        isMfaRequired: true,
+        isFirstFactorTokenPresent: true,
         firstFactorToken: firstFactorToken1,
         authentication: {
           firstFactor: {
@@ -113,7 +113,7 @@ describe("MFA service", () => {
         "uf_test_first_factor_12345d56ce7e4ae3677ea0918fbabcde";
       const mockResponse2 = {
         message: "MFA required",
-        isMfaRequired: true,
+        isFirstFactorTokenPresent: true,
         firstFactorToken: firstFactorToken2,
         authentication: {
           firstFactor: {
@@ -175,14 +175,14 @@ describe("MFA service", () => {
     });
   });
 
-  describe("isMfaRequired()", () => {
+  describe("isFirstFactorTokenPresent()", () => {
     it("should return true if MFA is currently required", () => {
       authenticationData.firstFactorToken = "uf_live_first_factor_sometoken";
-      expect(isMfaRequired()).toEqual(true);
+      expect(isFirstFactorTokenPresent()).toEqual(true);
     });
     it("should return false if MFA is not currently required", () => {
       authenticationData.firstFactorToken = "";
-      expect(isMfaRequired()).toEqual(false);
+      expect(isFirstFactorTokenPresent()).toEqual(false);
     });
   });
 

--- a/test/mode.spec.js
+++ b/test/mode.spec.js
@@ -60,7 +60,7 @@ describe("Mode tests", () => {
           authentication: {
             firstFactors: [{ channel: "email", strategy: "password" }],
             secondFactors: [],
-            isMfaRequired: false,
+            isFirstFactorTokenPresent: false,
             isEnabled: true,
           },
         },
@@ -89,7 +89,7 @@ describe("Mode tests", () => {
           authentication: {
             firstFactors: [{ channel: "email", strategy: "password" }],
             secondFactors: [],
-            isMfaRequired: false,
+            isFirstFactorTokenPresent: false,
             isEnabled: true,
           },
         },
@@ -118,7 +118,7 @@ describe("Mode tests", () => {
           authentication: {
             firstFactors: [{ channel: "email", strategy: "password" }],
             secondFactors: [],
-            isMfaRequired: false,
+            isFirstFactorTokenPresent: false,
             isEnabled: true,
           },
         },
@@ -147,7 +147,7 @@ describe("Mode tests", () => {
           authentication: {
             firstFactors: [{ channel: "email", strategy: "password" }],
             secondFactors: [],
-            isMfaRequired: false,
+            isFirstFactorTokenPresent: false,
             isEnabled: true,
           },
         },

--- a/test/totp.spec.js
+++ b/test/totp.spec.js
@@ -244,7 +244,6 @@ describe("loginWithTotp()", () => {
 
     // Call loginWithTotp()
     const payload = {
-      userId: 123,
       totpCode: "123456",
     };
     await loginWithTotp({

--- a/test/verificationCode.spec.js
+++ b/test/verificationCode.spec.js
@@ -142,11 +142,6 @@ describe("sendVerificationCode()", () => {
 
     const payload = {
       channel: "sms",
-      phoneNumber: "+15558769098",
-      email: "user@example.com",
-      username: "new-by-sms",
-      name: "New User",
-      data: { attr: "custom-data" },
     };
 
     // Call sendVerificationCode()
@@ -369,7 +364,6 @@ describe("loginWithVerificationCode()", () => {
     // Call loginWithVerificationCode()
     const payload = {
       channel: "sms",
-      phoneNumber: "+15558769912",
       verificationCode: "123467",
     };
     await loginWithVerificationCode(payload);
@@ -380,7 +374,6 @@ describe("loginWithVerificationCode()", () => {
       {
         tenantId,
         channel: payload.channel,
-        phoneNumber: payload.phoneNumber,
         verificationCode: payload.verificationCode,
       },
       mfaHeaders


### PR DESCRIPTION
Normal
Closes [DEV-369](https://linear.app/userfront/issue/DEV-369/allow-mfa-in-sdk-without-including-phonenumber-or-email)

- Removes the requirement for `phoneNumber` or `email` in the payload whenever a `firstFactorToken` is present. This change is to match an update to the API.
- Renames `isMfaRequired()` to `isFirstFactorTokenPresent()` to more accurately reflect what is happening