### PR TITLE
Revert incorrect isFirstFactorTokenPresent instances

### DIFF
--- a/src/mfa.js
+++ b/src/mfa.js
@@ -46,7 +46,7 @@ export function isFirstFactorTokenPresent() {
  * @param {Object} data
  */
 export function defaultHandleMfaRequired(firstFactorToken, data) {
-  if (!data.isFirstFactorTokenPresent) {
+  if (!data.isMfaRequired) {
     // If we've logged in or signed up successfully,
     // clear the MFA service state.
     if (data.message === "OK") {

--- a/test/config/utils.js
+++ b/test/config/utils.js
@@ -153,7 +153,7 @@ export function createMfaRequiredResponse({
   const response = {
     mode: mode || "live",
     message: "MFA required",
-    isFirstFactorTokenPresent: true,
+    isMfaRequired: true,
     firstFactorToken: createFirstFactorToken(),
     authentication: {
       firstFactor: _firstFactor,

--- a/test/init-ssr.spec.js
+++ b/test/init-ssr.spec.js
@@ -71,8 +71,6 @@ describe("init() method in Node/SSR environment (should not crash)", () => {
           authentication: {
             firstFactors: [],
             secondFactors: [],
-            isFirstFactorTokenPresent: false,
-            isEnabled: false,
           },
         },
       });

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -58,8 +58,6 @@ describe("init() method with domain option", () => {
         authentication: {
           firstFactors: [],
           secondFactors: [],
-          isFirstFactorTokenPresent: false,
-          isEnabled: false,
         },
       },
     });

--- a/test/mfa.spec.js
+++ b/test/mfa.spec.js
@@ -48,7 +48,7 @@ describe("MFA service", () => {
     it("should set the MFA service state if it is an MFA Required response", () => {
       const mockResponse = {
         message: "MFA required",
-        isFirstFactorTokenPresent: true,
+        isMfaRequired: true,
         firstFactorToken:
           "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a",
         authentication: {
@@ -88,7 +88,7 @@ describe("MFA service", () => {
         "uf_test_first_factor_207a4d56ce7e40bc9dafb0918fb6599a";
       const mockResponse1 = {
         message: "MFA required",
-        isFirstFactorTokenPresent: true,
+        isMfaRequired: true,
         firstFactorToken: firstFactorToken1,
         authentication: {
           firstFactor: {
@@ -113,7 +113,7 @@ describe("MFA service", () => {
         "uf_test_first_factor_12345d56ce7e4ae3677ea0918fbabcde";
       const mockResponse2 = {
         message: "MFA required",
-        isFirstFactorTokenPresent: true,
+        isMfaRequired: true,
         firstFactorToken: firstFactorToken2,
         authentication: {
           firstFactor: {

--- a/test/mode.spec.js
+++ b/test/mode.spec.js
@@ -60,8 +60,6 @@ describe("Mode tests", () => {
           authentication: {
             firstFactors: [{ channel: "email", strategy: "password" }],
             secondFactors: [],
-            isFirstFactorTokenPresent: false,
-            isEnabled: true,
           },
         },
       });
@@ -89,8 +87,6 @@ describe("Mode tests", () => {
           authentication: {
             firstFactors: [{ channel: "email", strategy: "password" }],
             secondFactors: [],
-            isFirstFactorTokenPresent: false,
-            isEnabled: true,
           },
         },
       });
@@ -118,8 +114,6 @@ describe("Mode tests", () => {
           authentication: {
             firstFactors: [{ channel: "email", strategy: "password" }],
             secondFactors: [],
-            isFirstFactorTokenPresent: false,
-            isEnabled: true,
           },
         },
       });
@@ -147,8 +141,6 @@ describe("Mode tests", () => {
           authentication: {
             firstFactors: [{ channel: "email", strategy: "password" }],
             secondFactors: [],
-            isFirstFactorTokenPresent: false,
-            isEnabled: true,
           },
         },
       });


### PR DESCRIPTION
Glance
Closes DEV-377

- There were a few instances where `isMfaRequired` should not have been renamed, but was. This PR reverts those instances so that the API response is properly handled.