### PR TITLE
Add MFA handling for updatePassword

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.5-0",
+  "version": "0.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.6.5-0",
+      "version": "0.6.5",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.4",
+  "version": "0.6.5-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "0.6.4",
+      "version": "0.6.5-0",
       "dependencies": {
         "axios": "^0.21.1",
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.5-beta.1",
+  "version": "0.6.5",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.5-0",
+  "version": "0.6.5-alpha.1",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.5-alpha.1",
+  "version": "0.6.5",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.4",
+  "version": "0.6.5-0",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "0.6.5",
+  "version": "0.6.5-beta.1",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",
@@ -9,11 +9,10 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "build": "npm version patch && npm run build:standard && npm run build:ie11 && npm run ts:copy",
+    "build": "npm run build:standard && npm run build:ie11 && npm run ts:copy",
     "build:standard": "microbundle && microbundle -f modern --external none",
     "build:ie11": "patch-package && COMPAT=ie11 microbundle -o build/userfront-core.ie11.umd.js --external none --no-pkg-main -f umd ; patch-package --reverse",
     "pub": "npm publish",
-    "build:beta": "npm version prerelease --preid=beta && npm run build:standard && npm run build:ie11 && npm run ts:copy",
     "pub:beta": "npm publish --tag beta",
     "reinstall": "rm -rf node_modules && rm package-lock.json && npm install",
     "ts:copy": "cp ts/index.d.ts build/userfront-core.d.ts; cp ts/index.d.ts build/userfront-core.modern.d.ts; cp ts/index.d.ts build/userfront-core.module.d.ts; cp ts/index.d.ts build/userfront-core.umd.d.ts",

--- a/src/password.js
+++ b/src/password.js
@@ -160,6 +160,11 @@ export async function sendResetLink(email) {
  * @property {String} uuid
  * @property {String} token
  * @property {String} redirect
+ * @property {Function} handleUpstreamResponse - 
+ * @property {Function} handleMfaRequired
+ * @property {Function} handlePkceRequired
+ * @property {Function} handleTokens
+ * @property {Function} handleRedirect
  * @returns
  */
 export async function updatePassword({
@@ -169,11 +174,26 @@ export async function updatePassword({
   uuid,
   token,
   redirect,
+  handleUpstreamResponse,
+  handleMfaRequired,
+  handlePkceRequired,
+  handleTokens,
+  handleRedirect,
 }) {
   switch (method) {
     // Allow for explicit setting of method
     case "link":
-      return updatePasswordWithLink({ uuid, token, password, redirect });
+      return updatePasswordWithLink({
+        uuid,
+        token,
+        password,
+        redirect,
+        handleUpstreamResponse,
+        handleMfaRequired,
+        handlePkceRequired,
+        handleTokens,
+        handleRedirect,
+      });
     case "jwt":
       return updatePasswordWithJwt({ password, existingPassword });
     default:
@@ -181,7 +201,17 @@ export async function updatePassword({
       token = token || getQueryAttr("token");
       uuid = uuid || getQueryAttr("uuid");
       if (uuid && token) {
-        return updatePasswordWithLink({ uuid, token, password, redirect });
+        return updatePasswordWithLink({
+          uuid,
+          token,
+          password,
+          redirect,
+          handleUpstreamResponse,
+          handleMfaRequired,
+          handlePkceRequired,
+          handleTokens,
+          handleRedirect,
+        });
       } else if (store.tokens.accessToken) {
         return updatePasswordWithJwt({ password, existingPassword });
       } else {
@@ -199,6 +229,11 @@ export async function updatePasswordWithLink({
   token,
   password,
   redirect,
+  handleUpstreamResponse,
+  handleMfaRequired,
+  handlePkceRequired,
+  handleTokens,
+  handleRedirect,
 }) {
   try {
     token = token || getQueryAttr("token");
@@ -210,15 +245,15 @@ export async function updatePasswordWithLink({
       token,
       password,
     });
-    if (data.tokens) {
-      setCookiesAndTokens(data.tokens);
-      defaultHandleRedirect(redirect, data);
-      return data;
-    } else {
-      throw new Error(
-        "There was a problem resetting your password. Please try again."
-      );
-    }
+    return handleLoginResponse({
+      data,
+      redirect,
+      handleUpstreamResponse,
+      handleMfaRequired,
+      handlePkceRequired,
+      handleTokens,
+      handleRedirect,
+    });
   } catch (error) {
     throwFormattedError(error);
   }
@@ -245,6 +280,10 @@ export async function updatePasswordWithJwt({ password, existingPassword }) {
         },
       }
     );
+
+    if (typeof handleUpstreamResponse === "function") {
+      await handleUpstreamResponse(data.upstreamResponse, data);
+    }
 
     return data;
   } catch (error) {

--- a/src/password.js
+++ b/src/password.js
@@ -281,10 +281,6 @@ export async function updatePasswordWithJwt({ password, existingPassword }) {
       }
     );
 
-    if (typeof handleUpstreamResponse === "function") {
-      await handleUpstreamResponse(data.upstreamResponse, data);
-    }
-
     return data;
   } catch (error) {
     throwFormattedError(error);

--- a/test/reset.spec.js
+++ b/test/reset.spec.js
@@ -260,8 +260,6 @@ describe("updatePassword()", () => {
     });
 
     it("should handle an MFA Required response", async () => {
-      // should start ok
-      expect(Userfront.tokens.accessToken).toBeFalsy();
       // Return an MFA Required response
       api.put.mockImplementationOnce(() => mockMfaRequiredResponse);
 
@@ -346,9 +344,8 @@ describe("updatePassword()", () => {
       // Should return the correct value
       expect(totpData).toEqual(mockTotpResponse.data);
 
+      // Tokens should be set now
       expect(Userfront.tokens.accessToken).toEqual(totpData.tokens.access.value);
-
-      console.log("%%%%%%%% end")
     });
 
     it(`error should respond with whatever error the server sends`, async () => {
@@ -369,13 +366,13 @@ describe("updatePassword()", () => {
     });
   });
 
-  describe.skip("updatePasswordWithJwt()", () => {
-    beforeAll(() => {
+  describe("updatePasswordWithJwt()", () => {
+    beforeEach(() => {
       // Add JWT access token
       setCookiesAndTokens(mockResponse.data.tokens);
     });
 
-    afterAll(() => {
+    afterEach(() => {
       // Remove JWT access token
       removeAllCookies();
     });

--- a/test/reset.spec.js
+++ b/test/reset.spec.js
@@ -5,6 +5,7 @@ import {
   createIdToken,
   createRefreshToken,
   idTokenUserDefaults,
+  createMfaRequiredResponse,
   mockWindow,
 } from "./config/utils.js";
 import { removeAllCookies } from "../src/cookies.js";
@@ -16,6 +17,9 @@ import {
   updatePasswordWithLink,
   updatePasswordWithJwt,
 } from "../src/password.js";
+import { unsetTokens } from "../src/tokens.js";
+import { loginWithTotp } from "../src/totp.js";
+import { assertAuthenticationDataMatches, mfaHeaders } from "./config/assertions.js";
 
 jest.mock("../src/api.js");
 
@@ -38,6 +42,14 @@ const mockResponse = {
     redirectTo: "/dashboard",
   },
 };
+
+// Mock "MFA Required" API response
+const mockMfaRequiredResponse = createMfaRequiredResponse({
+  firstFactor: {
+    strategy: "password",
+    channel: "email",
+  },
+});
 
 describe("sendResetLink()", () => {
   beforeEach(() => {
@@ -74,6 +86,7 @@ describe("updatePassword()", () => {
     jest.resetAllMocks();
     // Remove token and uuid from the URL
     window.location.href = "https://example.com/reset";
+    unsetTokens();
   });
 
   describe("No method set (method is inferred)", () => {
@@ -246,6 +259,98 @@ describe("updatePassword()", () => {
       expect(window.location.assign).not.toHaveBeenCalled();
     });
 
+    it("should handle an MFA Required response", async () => {
+      // should start ok
+      expect(Userfront.tokens.accessToken).toBeFalsy();
+      // Return an MFA Required response
+      api.put.mockImplementationOnce(() => mockMfaRequiredResponse);
+
+      const payload = {
+        token: "token",
+        uuid: "uuid",
+        password: "password"
+      };
+
+      // Send the request
+      const data = await updatePasswordWithLink({ ...payload });
+
+      // Should have update the MFA service state
+      assertAuthenticationDataMatches(mockMfaRequiredResponse);
+
+      // Should not have set the user object or redirected
+      expect(Userfront.tokens.accessToken).toBeFalsy();
+      expect(window.location.assign).not.toHaveBeenCalled();
+
+      // Should have returned MFA options & firstFactorToken
+      expect(data).toEqual(mockMfaRequiredResponse.data);
+    });
+
+    it("should handle an MFA Required response followed by a second factor", async () => {
+      // Return an MFA Required response
+      api.put.mockImplementationOnce(() => mockMfaRequiredResponse);
+
+      const payload = {
+        token: "token",
+        uuid: "uuid",
+        password: "password"
+      };
+
+      // Send the request
+      const data = await updatePasswordWithLink({ ...payload });
+
+      // Should have update the MFA service state
+      assertAuthenticationDataMatches(mockMfaRequiredResponse);
+
+      // Should not have set the user object or redirected
+      expect(Userfront.tokens.accessToken).toBeFalsy();
+      expect(window.location.assign).not.toHaveBeenCalled();
+
+      // Should have returned MFA options & firstFactorToken
+      expect(data).toEqual(mockMfaRequiredResponse.data);
+
+      // Mock TOTP login response
+      const mockTotpResponse = {
+        data: {
+          tokens: {
+            access: { value: createAccessToken() },
+            id: { value: createIdToken() },
+            refresh: { value: createRefreshToken() },
+          },
+          nonce: "nonce-value",
+          redirectTo: "/dashboard",
+        },
+      };
+
+      // Return a success response for TOTP second factor
+      api.post.mockImplementationOnce(() => mockTotpResponse);
+
+      // Call loginWithTotp() as second factor
+      const totpPayload = {
+        totpCode: "123456",
+      };
+      const totpData = await loginWithTotp({
+        redirect: false,
+        ...totpPayload,
+      });
+
+      // Should have sent the proper API request
+      expect(api.post).toHaveBeenCalledWith(
+        `/auth/totp`,
+        {
+          tenantId,
+          ...totpPayload,
+        },
+        mfaHeaders
+      );
+
+      // Should return the correct value
+      expect(totpData).toEqual(mockTotpResponse.data);
+
+      expect(Userfront.tokens.accessToken).toEqual(totpData.tokens.access.value);
+
+      console.log("%%%%%%%% end")
+    });
+
     it(`error should respond with whatever error the server sends`, async () => {
       // Mock the API response
       const mockResponse = {
@@ -264,7 +369,7 @@ describe("updatePassword()", () => {
     });
   });
 
-  describe("updatePasswordWithJwt()", () => {
+  describe.skip("updatePasswordWithJwt()", () => {
     beforeAll(() => {
       // Add JWT access token
       setCookiesAndTokens(mockResponse.data.tokens);


### PR DESCRIPTION
Normal
Closes DEV-487

If the user has MFA configured and is trying to update their password with link credentials, `Userfront.updatePassword()` will now return an `MFA Required` response object. The client must call `Userfront.login()` with a valid second factor to finalize the password update.

`Userfront.updatePassword()` for users without MFA configured or with JWT credentials is not changed.

 * @property {Function} handleUpstreamResponse - 
 * @property {Function} handleMfaRequired
 * @property {Function} handlePkceRequired
 * @property {Function} handleTokens
 * @property {Function} handleRedirect

This additionally allows the client to pass in their own `handleMfaRequired`, `handleTokens` and `handleRedirect` methods to `Userfront.updatePassword()`. (To keep the method signatures similar, `handleUpstreamResponse` and `handlePkceRequired` can be passed in as well, but neither are expected to happen with a password reset.)

Also removed `npm version` from the `build` scripts in `package.json`, running a build doesn't imply a version update.

TODO after approval & before merge:
- [x] Publish

TODO after merge:
- [ ] Update docs