### PR TITLE
add missing type 

### DIFF
--- a/ts/index.d.ts
+++ b/ts/index.d.ts
@@ -304,3 +304,5 @@ export declare function sendVerificationCode({
   username?: string;
   data?: object;
 }): Promise<VerificationCodeResponse>;
+
+export declare function build(options: { toolId: string });


### PR DESCRIPTION
There is a missing type in index.d.ts in userfront-core when using types in userfront-react.
Use it in Next.js and need the type information to build.
https://github.com/userfront/userfront-react/issues/20#issuecomment-1622888550
