### PR TITLE
[ISC-248] Use `tenantId` in API URL instead of body

### DIFF
--- a/archive/mfa.js
+++ b/archive/mfa.js
@@ -55,8 +55,9 @@ export async function sendMfaCode({
   }
 
   try {
-    const { data } = await post(`/auth/mfa`, {
-      tenantId: store.tenantId,
+    const { tenantId } = store;
+
+    const { data } = await post(`/tenants/${tenantId}/auth/mfa`, {
       firstFactorCode,
       strategy,
       channel,
@@ -86,8 +87,8 @@ export async function loginWithMfa({
   }
 
   try {
-    const { data } = await put(`/auth/mfa`, {
-      tenantId: store.tenantId,
+    const { tenantId } = store;
+    const { data } = await put(`/tenants/${tenantId}/auth/mfa`, {
       firstFactorCode,
       verificationCode,
     });

--- a/src/link.js
+++ b/src/link.js
@@ -33,12 +33,13 @@ export async function loginWithLink({
     uuid = uuid || getQueryAttr("uuid");
     if (!token || !uuid) return;
 
+    const { tenantId } = store;
+
     const { data } = await put(
-      "/auth/link",
+      `/tenants/${tenantId}/auth/link`,
       {
         token,
         uuid,
-        tenantId: store.tenantId,
       },
       {
         headers: getMfaHeaders(),
@@ -67,9 +68,10 @@ export async function loginWithLink({
  */
 export async function sendLoginLink(email) {
   try {
-    const { data } = await post(`/auth/link`, {
+    const { tenantId } = store;
+
+    const { data } = await post(`/tenants/${tenantId}/auth/link`, {
       email,
-      tenantId: store.tenantId,
     });
     return data;
   } catch (error) {
@@ -89,13 +91,14 @@ export async function sendPasswordlessLink({
   options,
 }) {
   try {
-    const { data } = await post(`/auth/link`, {
+    const { tenantId } = store;
+
+    const { data } = await post(`/tenants/${tenantId}/auth/link`, {
       email,
       name,
       username,
       data: userData,
       options,
-      tenantId: store.tenantId,
     });
     return data;
   } catch (error) {

--- a/src/password.js
+++ b/src/password.js
@@ -36,10 +36,10 @@ export async function signupWithPassword({
   handleRedirect,
 } = {}) {
   try {
+    const { tenantId } = store;
     const { data } = await post(
-      `/auth/create`,
+      `/tenants/${tenantId}/auth/create`,
       {
-        tenantId: store.tenantId,
         username,
         name,
         email,
@@ -102,7 +102,6 @@ export async function loginWithPassword({
 }) {
   try {
     const body = {
-      tenantId: store.tenantId,
       emailOrUsername: email || username || emailOrUsername,
       password,
     };
@@ -111,7 +110,8 @@ export async function loginWithPassword({
         noResetEmail: true,
       };
     }
-    const { data } = await post(`/auth/basic`, body, {
+    const { tenantId } = store;
+    const { data } = await post(`/tenants/${tenantId}/auth/basic`, body, {
       headers: getMfaHeaders(),
       params: getPkceRequestQueryParams(),
     });
@@ -137,9 +137,9 @@ export async function loginWithPassword({
  */
 export async function sendResetLink(email) {
   try {
-    const { data } = await post(`/auth/reset/link`, {
+    const { tenantId } = store;
+    const { data } = await post(`/tenants/${tenantId}/auth/reset/link`, {
       email,
-      tenantId: store.tenantId,
     });
     return data;
   } catch (error) {
@@ -160,7 +160,7 @@ export async function sendResetLink(email) {
  * @property {String} uuid
  * @property {String} token
  * @property {String} redirect
- * @property {Function} handleUpstreamResponse - 
+ * @property {Function} handleUpstreamResponse -
  * @property {Function} handleMfaRequired
  * @property {Function} handlePkceRequired
  * @property {Function} handleTokens
@@ -239,8 +239,8 @@ export async function updatePasswordWithLink({
     token = token || getQueryAttr("token");
     uuid = uuid || getQueryAttr("uuid");
     if (!token || !uuid) throw new Error("Missing token or uuid");
-    const { data } = await put(`/auth/reset`, {
-      tenantId: store.tenantId,
+    const { tenantId } = store;
+    const { data } = await put(`/tenants/${tenantId}/auth/reset`, {
       uuid,
       token,
       password,
@@ -267,10 +267,10 @@ export async function updatePasswordWithJwt({ password, existingPassword }) {
       );
     }
 
+    const { tenantId } = store;
     const { data } = await put(
-      `/auth/basic`,
+      `/tenants/${tenantId}/auth/basic`,
       {
-        tenantId: store.tenantId,
         password,
         existingPassword,
       },

--- a/src/password.migrate.js
+++ b/src/password.migrate.js
@@ -40,7 +40,6 @@ export async function loginWithPasswordMigrate({
 }) {
   try {
     const body = {
-      tenantId: store.tenantId,
       emailOrUsername: email || username || emailOrUsername,
       password,
     };
@@ -49,12 +48,17 @@ export async function loginWithPasswordMigrate({
         noResetEmail: true,
       };
     }
+    const { tenantId } = store;
 
     // Make the request to password/migrate
-    const { data } = await post(`/auth/password/migrate`, body, {
-      headers: getMfaHeaders(),
-      params: getPkceRequestQueryParams(),
-    });
+    const { data } = await post(
+      `/tenants/${tenantId}/auth/password/migrate`,
+      body,
+      {
+        headers: getMfaHeaders(),
+        params: getPkceRequestQueryParams(),
+      }
+    );
 
     // Handle the API response to the login request
     return handleLoginResponse({

--- a/src/totp.js
+++ b/src/totp.js
@@ -36,8 +36,9 @@ export async function loginWithTotp({
   handleRedirect,
 } = {}) {
   try {
+    const { tenantId } = store;
     const { data } = await post(
-      `/auth/totp`,
+      `/tenants/${tenantId}/auth/totp`,
       {
         totpCode,
         backupCode,
@@ -47,7 +48,6 @@ export async function loginWithTotp({
         email,
         username,
         phoneNumber,
-        tenantId: store.tenantId,
       },
       {
         headers: getMfaHeaders(),

--- a/src/verificationCode.js
+++ b/src/verificationCode.js
@@ -54,8 +54,10 @@ export async function sendVerificationCode({
       email,
     });
 
+    const { tenantId } = store;
+
     const { data: res } = await post(
-      `/auth/code`,
+      `/tenants/${tenantId}/auth/code`,
       {
         channel,
         email,
@@ -63,7 +65,6 @@ export async function sendVerificationCode({
         name,
         username,
         data,
-        tenantId: store.tenantId,
       },
       {
         headers: getMfaHeaders(),
@@ -101,14 +102,14 @@ export async function loginWithVerificationCode({
       email,
     });
 
+    const { tenantId } = store;
     const { data } = await put(
-      `/auth/code`,
+      `/tenants/${tenantId}/auth/code`,
       {
         channel,
         verificationCode,
         email,
         phoneNumber,
-        tenantId: store.tenantId,
       },
       {
         headers: getMfaHeaders(),

--- a/test/init-ssr.spec.js
+++ b/test/init-ssr.spec.js
@@ -100,14 +100,13 @@ describe("init() method in Node/SSR environment (should not crash)", () => {
       expect(axios.defaults.headers.common["x-application-id"]).toEqual(url);
       expect(axios.defaults.headers.common["x-origin"]).toEqual(url);
       expect(axios.post).toHaveBeenCalledWith(
-        "https://api.userfront.com/v0/auth/create",
+        `https://api.userfront.com/v0/tenants/${tenantId}/auth/create`,
         {
           email,
           password,
           username: undefined,
           name: undefined,
           data: undefined,
-          tenantId,
         },
         noMfaHeaders
       );
@@ -127,11 +126,10 @@ describe("init() method in Node/SSR environment (should not crash)", () => {
       expect(axios.defaults.headers.common["x-origin"]).toEqual(url);
 
       expect(axios.post).toHaveBeenCalledWith(
-        "https://api.userfront.com/v0/auth/basic",
+        `https://api.userfront.com/v0/tenants/${tenantId}/auth/basic`,
         {
           emailOrUsername: email,
           password,
-          tenantId,
         },
         noMfaHeaders
       );

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -87,14 +87,13 @@ describe("init() method with domain option", () => {
     expect(axios.defaults.headers.common["x-application-id"]).toEqual(url);
     expect(axios.defaults.headers.common["x-origin"]).toEqual(url);
     expect(axios.post).toHaveBeenCalledWith(
-      "https://api.userfront.com/v0/auth/create",
+      `https://api.userfront.com/v0/tenants/${tenantId}/auth/create`,
       {
         email,
         password,
         username: undefined,
         name: undefined,
         data: undefined,
-        tenantId,
       },
       noMfaHeaders
     );
@@ -114,11 +113,10 @@ describe("init() method with domain option", () => {
     expect(axios.defaults.headers.common["x-origin"]).toEqual(url);
 
     expect(axios.post).toHaveBeenCalledWith(
-      "https://api.userfront.com/v0/auth/basic",
+      `https://api.userfront.com/v0/tenants/${tenantId}/auth/basic`,
       {
         emailOrUsername: email,
         password,
-        tenantId,
       },
       noMfaHeaders
     );

--- a/test/link.spec.js
+++ b/test/link.spec.js
@@ -81,8 +81,7 @@ describe("sendLoginLink", () => {
     const data = await sendLoginLink(mockResponse.data.result.email);
 
     // Should have sent the proper API request
-    expect(api.post).toHaveBeenCalledWith(`/auth/link`, {
-      tenantId,
+    expect(api.post).toHaveBeenCalledWith(`/tenants/${tenantId}/auth/link`, {
       email: mockResponse.data.result.email,
     });
 
@@ -143,10 +142,10 @@ describe("sendPasswordlessLink", () => {
     });
 
     // Should have sent the proper API request
-    expect(api.post).toHaveBeenCalledWith(`/auth/link`, {
-      tenantId,
-      ...payload,
-    });
+    expect(api.post).toHaveBeenCalledWith(
+      `/tenants/${tenantId}/auth/link`,
+      payload
+    );
 
     // Should have returned the response exactly
     expect(data).toEqual(mockResponse.data);
@@ -199,11 +198,8 @@ describe("loginWithLink", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/link`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/link`,
+      payload,
       noMfaHeaders
     );
 
@@ -244,11 +240,8 @@ describe("loginWithLink", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/link`,
-      {
-        tenantId,
-        ...query,
-      },
+      `/tenants/${tenantId}/auth/link`,
+      query,
       noMfaHeaders
     );
 
@@ -277,11 +270,8 @@ describe("loginWithLink", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/link`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/link`,
+      payload,
       noMfaHeaders
     );
 
@@ -307,11 +297,8 @@ describe("loginWithLink", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/link`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/link`,
+      payload,
       noMfaHeaders
     );
 
@@ -338,11 +325,8 @@ describe("loginWithLink", () => {
 
     // Should have send the correct API request, with MFA headers attached
     expect(api.put).toHaveBeenCalledWith(
-      "/auth/link",
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/link`,
+      payload,
       mfaHeaders
     );
   });
@@ -371,11 +355,8 @@ describe("loginWithLink", () => {
 
       // Should have sent the proper API request
       expect(api.put).toHaveBeenCalledWith(
-        `/auth/link`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/link`,
+        payload,
         pkceParams("code")
       );
     });
@@ -395,11 +376,8 @@ describe("loginWithLink", () => {
 
       // Should have sent the proper API request
       expect(api.put).toHaveBeenCalledWith(
-        `/auth/link`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/link`,
+        payload,
         pkceParams("code")
       );
 

--- a/test/password-migrate.spec.js
+++ b/test/password-migrate.spec.js
@@ -89,11 +89,8 @@ describe("loginWithPasswordMigrate()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/password/migrate`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/password/migrate`,
+        payload,
         noMfaHeaders
       );
 
@@ -124,9 +121,8 @@ describe("loginWithPasswordMigrate()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/password/migrate`,
+        `/tenants/${tenantId}/auth/password/migrate`,
         {
-          tenantId,
           emailOrUsername: payload.emailOrUsername,
           password: payload.password,
         },
@@ -173,9 +169,8 @@ describe("loginWithPasswordMigrate()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/password/migrate`,
+        `/tenants/${tenantId}/auth/password/migrate`,
         {
-          tenantId,
           emailOrUsername: payload.email,
           password: payload.password,
         },
@@ -208,11 +203,8 @@ describe("loginWithPasswordMigrate()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/password/migrate`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/password/migrate`,
+        payload,
         noMfaHeaders
       );
 
@@ -242,9 +234,8 @@ describe("loginWithPasswordMigrate()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/password/migrate`,
+        `/tenants/${tenantId}/auth/password/migrate`,
         {
-          tenantId,
           ...payload,
           options: {
             noResetEmail: true,
@@ -286,9 +277,8 @@ describe("loginWithPasswordMigrate()", () => {
 
       // Should have sent the correct API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/password/migrate`,
+        `/tenants/${tenantId}/auth/password/migrate`,
         {
-          tenantId,
           emailOrUsername: payload.email,
           password: payload.password,
         },
@@ -318,9 +308,8 @@ describe("loginWithPasswordMigrate()", () => {
 
       // Should have sent the correct API request, with MFA headers
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/password/migrate`,
+        `/tenants/${tenantId}/auth/password/migrate`,
         {
-          tenantId,
           emailOrUsername: payload.email,
           password: payload.password,
         },
@@ -345,11 +334,8 @@ describe("loginWithPasswordMigrate()", () => {
 
         // Should have sent the proper API request
         expect(api.post).toHaveBeenCalledWith(
-          `/auth/password/migrate`,
-          {
-            tenantId,
-            ...payload,
-          },
+          `/tenants/${tenantId}/auth/password/migrate`,
+          payload,
           pkceParams("code")
         );
       });
@@ -368,11 +354,8 @@ describe("loginWithPasswordMigrate()", () => {
 
         // Should have sent the proper API request
         expect(api.post).toHaveBeenCalledWith(
-          `/auth/password/migrate`,
-          {
-            tenantId,
-            ...payload,
-          },
+          `/tenants/${tenantId}/auth/password/migrate`,
+          payload,
           pkceParams("code")
         );
 

--- a/test/password.spec.js
+++ b/test/password.spec.js
@@ -79,9 +79,8 @@ describe("signupWithPassword()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/create`,
+      `/tenants/${tenantId}/auth/create`,
       {
-        tenantId,
         email: payload.email,
         name: payload.name,
         data: payload.userData,
@@ -114,9 +113,8 @@ describe("signupWithPassword()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/create`,
+      `/tenants/${tenantId}/auth/create`,
       {
-        tenantId,
         email: payload.email,
         password: payload.password,
       },
@@ -157,11 +155,8 @@ describe("signupWithPassword()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/create`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/create`,
+      payload,
       noMfaHeaders
     );
 
@@ -207,9 +202,8 @@ describe("signupWithPassword()", () => {
 
     // Should have sent the correct API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/create`,
+      `/tenants/${tenantId}/auth/create`,
       {
-        tenantId,
         email: payload.email,
         password: payload.password,
       },
@@ -239,9 +233,8 @@ describe("signupWithPassword()", () => {
 
     // Should have sent the correct API request, with MFA headers
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/create`,
+      `/tenants/${tenantId}/auth/create`,
       {
-        tenantId,
         email: payload.email,
         password: payload.password,
       },
@@ -271,11 +264,8 @@ describe("loginWithPassword()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/basic`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/basic`,
+        payload,
         noMfaHeaders
       );
 
@@ -313,9 +303,8 @@ describe("loginWithPassword()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/basic`,
+        `/tenants/${tenantId}/auth/basic`,
         {
-          tenantId,
           emailOrUsername: payload.email,
           password: payload.password,
         },
@@ -347,11 +336,8 @@ describe("loginWithPassword()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/basic`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/basic`,
+        payload,
         noMfaHeaders
       );
 
@@ -381,9 +367,8 @@ describe("loginWithPassword()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/basic`,
+        `/tenants/${tenantId}/auth/basic`,
         {
-          tenantId,
           ...payload,
           options: {
             noResetEmail: true,
@@ -425,9 +410,8 @@ describe("loginWithPassword()", () => {
 
       // Should have sent the correct API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/basic`,
+        `/tenants/${tenantId}/auth/basic`,
         {
-          tenantId,
           emailOrUsername: payload.email,
           password: payload.password,
         },
@@ -457,9 +441,8 @@ describe("loginWithPassword()", () => {
 
       // Should have sent the correct API request, with MFA headers
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/basic`,
+        `/tenants/${tenantId}/auth/basic`,
         {
-          tenantId,
           emailOrUsername: payload.email,
           password: payload.password,
         },
@@ -482,11 +465,8 @@ describe("loginWithPassword()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/basic`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/basic`,
+        payload,
         noMfaHeaders
       );
 
@@ -518,11 +498,8 @@ describe("loginWithPassword()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/basic`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/basic`,
+        payload,
         noMfaHeaders
       );
 
@@ -568,9 +545,8 @@ describe("loginWithPassword()", () => {
 
         // Should have sent the proper API request
         expect(api.post).toHaveBeenCalledWith(
-          `/auth/create`,
+          `/tenants/${tenantId}/auth/create`,
           {
-            tenantId,
             email: payload.email,
             password: payload.password,
           },
@@ -592,9 +568,8 @@ describe("loginWithPassword()", () => {
 
         // Should have sent the proper API request
         expect(api.post).toHaveBeenCalledWith(
-          `/auth/create`,
+          `/tenants/${tenantId}/auth/create`,
           {
-            tenantId,
             email: payload.email,
             password: payload.password,
           },
@@ -624,11 +599,8 @@ describe("loginWithPassword()", () => {
 
         // Should have sent the proper API request
         expect(api.post).toHaveBeenCalledWith(
-          `/auth/basic`,
-          {
-            tenantId,
-            ...payload,
-          },
+          `/tenants/${tenantId}/auth/basic`,
+          payload,
           pkceParams("code")
         );
       });
@@ -647,11 +619,8 @@ describe("loginWithPassword()", () => {
 
         // Should have sent the proper API request
         expect(api.post).toHaveBeenCalledWith(
-          `/auth/basic`,
-          {
-            tenantId,
-            ...payload,
-          },
+          `/tenants/${tenantId}/auth/basic`,
+          payload,
           pkceParams("code")
         );
 

--- a/test/reset.spec.js
+++ b/test/reset.spec.js
@@ -19,7 +19,10 @@ import {
 } from "../src/password.js";
 import { unsetTokens } from "../src/tokens.js";
 import { loginWithTotp } from "../src/totp.js";
-import { assertAuthenticationDataMatches, mfaHeaders } from "./config/assertions.js";
+import {
+  assertAuthenticationDataMatches,
+  mfaHeaders,
+} from "./config/assertions.js";
 
 jest.mock("../src/api.js");
 
@@ -100,10 +103,10 @@ describe("updatePassword()", () => {
       await updatePassword(options);
 
       // Should have sent the proper API request
-      expect(api.put).toHaveBeenCalledWith(`/auth/reset`, {
-        tenantId,
-        ...options,
-      });
+      expect(api.put).toHaveBeenCalledWith(
+        `/tenants/${tenantId}/auth/reset`,
+        options
+      );
 
       // Should have redirected the page
       expect(window.location.assign).toHaveBeenCalledWith(
@@ -127,8 +130,7 @@ describe("updatePassword()", () => {
       await updatePassword(options);
 
       // Should have sent the proper API request
-      expect(api.put).toHaveBeenCalledWith(`/auth/reset`, {
-        tenantId,
+      expect(api.put).toHaveBeenCalledWith(`/tenants/${tenantId}/auth/reset`, {
         token: "aaaaa",
         uuid: "bbbbb",
         ...options,
@@ -156,11 +158,8 @@ describe("updatePassword()", () => {
 
       // Should have sent the proper API request
       expect(api.put).toHaveBeenCalledWith(
-        `/auth/basic`,
-        {
-          tenantId,
-          ...options,
-        },
+        `/tenants/${tenantId}/auth/basic`,
+        options,
         {
           headers: {
             Authorization: `Bearer ${mockResponse.data.tokens.access.value}`,
@@ -184,10 +183,10 @@ describe("updatePassword()", () => {
       await updatePasswordWithLink(options);
 
       // Should have sent the proper API request
-      expect(api.put).toHaveBeenCalledWith(`/auth/reset`, {
-        tenantId,
-        ...options,
-      });
+      expect(api.put).toHaveBeenCalledWith(
+        `/tenants/${tenantId}/auth/reset`,
+        options
+      );
 
       // Should have redirected the page
       expect(window.location.assign).toHaveBeenCalledWith(
@@ -219,10 +218,10 @@ describe("updatePassword()", () => {
       await updatePasswordWithLink({ ...options, redirect: targetPath });
 
       // Should have sent the proper API request
-      expect(api.put).toHaveBeenCalledWith(`/auth/reset`, {
-        tenantId,
-        ...options,
-      });
+      expect(api.put).toHaveBeenCalledWith(
+        `/tenants/${tenantId}/auth/reset`,
+        options
+      );
 
       // Should have set the user object
       expect(Userfront.user.email).toEqual(newUserAttrs.email);
@@ -246,10 +245,10 @@ describe("updatePassword()", () => {
       await updatePasswordWithLink({ ...options, redirect: false });
 
       // Should have sent the proper API request
-      expect(api.put).toHaveBeenCalledWith(`/auth/reset`, {
-        tenantId,
-        ...options,
-      });
+      expect(api.put).toHaveBeenCalledWith(
+        `/tenants/${tenantId}/auth/reset`,
+        options
+      );
 
       // Should have set the user object
       expect(Userfront.user.email).toEqual(idTokenUserDefaults.email);
@@ -266,7 +265,7 @@ describe("updatePassword()", () => {
       const payload = {
         token: "token",
         uuid: "uuid",
-        password: "password"
+        password: "password",
       };
 
       // Send the request
@@ -290,7 +289,7 @@ describe("updatePassword()", () => {
       const payload = {
         token: "token",
         uuid: "uuid",
-        password: "password"
+        password: "password",
       };
 
       // Send the request
@@ -333,11 +332,8 @@ describe("updatePassword()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/totp`,
-        {
-          tenantId,
-          ...totpPayload,
-        },
+        `/tenants/${tenantId}/auth/totp`,
+        totpPayload,
         mfaHeaders
       );
 
@@ -345,7 +341,9 @@ describe("updatePassword()", () => {
       expect(totpData).toEqual(mockTotpResponse.data);
 
       // Tokens should be set now
-      expect(Userfront.tokens.accessToken).toEqual(totpData.tokens.access.value);
+      expect(Userfront.tokens.accessToken).toEqual(
+        totpData.tokens.access.value
+      );
     });
 
     it(`error should respond with whatever error the server sends`, async () => {
@@ -391,11 +389,8 @@ describe("updatePassword()", () => {
 
       // Should have sent the proper API request
       expect(api.put).toHaveBeenCalledWith(
-        `/auth/basic`,
-        {
-          tenantId,
-          ...options,
-        },
+        `/tenants/${tenantId}/auth/basic`,
+        options,
         {
           headers: {
             Authorization: `Bearer ${mockResponse.data.tokens.access.value}`,

--- a/test/saml.spec.js
+++ b/test/saml.spec.js
@@ -8,9 +8,7 @@ import {
   idTokenUserDefaults,
   mockWindow,
 } from "./config/utils.js";
-import {
-  noMfaHeaders
-} from "./config/assertions.js";
+import { noMfaHeaders } from "./config/assertions.js";
 import { login } from "../src/login.js";
 import { logout } from "../src/logout.js";
 import { unsetTokens } from "../src/tokens.js";
@@ -93,10 +91,11 @@ describe("completeSamlLogin()", () => {
       ...payload,
     });
     // Should have sent the proper API request
-    expect(api.post).toHaveBeenCalledWith(`/auth/basic`, {
-      tenantId,
-      ...payload,
-    }, noMfaHeaders);
+    expect(api.post).toHaveBeenCalledWith(
+      `/tenants/${tenantId}/auth/basic`,
+      payload,
+      noMfaHeaders
+    );
 
     // Should have returned the proper value
     expect(data).toEqual(mockResponse.data);

--- a/test/totp.spec.js
+++ b/test/totp.spec.js
@@ -78,11 +78,8 @@ describe("loginWithTotp()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/totp`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/totp`,
+      payload,
       noMfaHeaders
     );
 
@@ -117,11 +114,8 @@ describe("loginWithTotp()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/totp`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/totp`,
+      payload,
       noMfaHeaders
     );
 
@@ -152,11 +146,8 @@ describe("loginWithTotp()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/totp`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/totp`,
+      payload,
       noMfaHeaders
     );
 
@@ -185,11 +176,8 @@ describe("loginWithTotp()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/totp`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/totp`,
+      payload,
       noMfaHeaders
     );
 
@@ -218,11 +206,8 @@ describe("loginWithTotp()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/totp`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/totp`,
+      payload,
       noMfaHeaders
     );
 
@@ -253,11 +238,8 @@ describe("loginWithTotp()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/totp`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/totp`,
+      payload,
       mfaHeaders
     );
   });
@@ -289,11 +271,8 @@ describe("loginWithTotp()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/totp`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/totp`,
+        payload,
         pkceParams("code")
       );
     });
@@ -317,11 +296,8 @@ describe("loginWithTotp()", () => {
 
       // Should have sent the proper API request
       expect(api.post).toHaveBeenCalledWith(
-        `/auth/totp`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/totp`,
+        payload,
         pkceParams("code")
       );
 

--- a/test/verificationCode.spec.js
+++ b/test/verificationCode.spec.js
@@ -63,11 +63,8 @@ describe("sendVerificationCode()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/code`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/code`,
+      payload,
       noMfaHeaders
     );
 
@@ -86,11 +83,8 @@ describe("sendVerificationCode()", () => {
 
     // Should have sent the proper API request
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/code`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/code`,
+      payload,
       noMfaHeaders
     );
 
@@ -149,11 +143,8 @@ describe("sendVerificationCode()", () => {
 
     // Should have sent the proper API request with MFA headers
     expect(api.post).toHaveBeenCalledWith(
-      `/auth/code`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/code`,
+      payload,
       mfaHeaders
     );
 
@@ -215,11 +206,8 @@ describe("loginWithVerificationCode()", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/code`,
-      {
-        tenantId,
-        ...payload,
-      },
+      `/tenants/${tenantId}/auth/code`,
+      payload,
       noMfaHeaders
     );
 
@@ -256,9 +244,8 @@ describe("loginWithVerificationCode()", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/code`,
+      `/tenants/${tenantId}/auth/code`,
       {
-        tenantId,
         channel: payload.channel,
         email: payload.email,
         verificationCode: payload.verificationCode,
@@ -299,9 +286,8 @@ describe("loginWithVerificationCode()", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/code`,
+      `/tenants/${tenantId}/auth/code`,
       {
-        tenantId,
         channel: payload.channel,
         phoneNumber: payload.phoneNumber,
         verificationCode: payload.verificationCode,
@@ -333,9 +319,8 @@ describe("loginWithVerificationCode()", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/code`,
+      `/tenants/${tenantId}/auth/code`,
       {
-        tenantId,
         channel: payload.channel,
         phoneNumber: payload.phoneNumber,
         verificationCode: payload.verificationCode,
@@ -370,9 +355,8 @@ describe("loginWithVerificationCode()", () => {
 
     // Should have sent the proper API request
     expect(api.put).toHaveBeenCalledWith(
-      `/auth/code`,
+      `/tenants/${tenantId}/auth/code`,
       {
-        tenantId,
         channel: payload.channel,
         verificationCode: payload.verificationCode,
       },
@@ -447,11 +431,8 @@ describe("loginWithVerificationCode()", () => {
 
       // Should have sent the proper API request
       expect(api.put).toHaveBeenCalledWith(
-        `/auth/code`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/code`,
+        payload,
         pkceParams("code")
       );
     });
@@ -484,11 +465,8 @@ describe("loginWithVerificationCode()", () => {
 
       // Should have sent the proper API request
       expect(api.put).toHaveBeenCalledWith(
-        `/auth/code`,
-        {
-          tenantId,
-          ...payload,
-        },
+        `/tenants/${tenantId}/auth/code`,
+        payload,
         pkceParams("code")
       );
 


### PR DESCRIPTION
Depth: Glance

Resolves: [ISC-248](https://linear.app/userfront/issue/ISC-248/use-long-paths-everywhere-in-core-js-and-toolkit)

# Description

In this pull request, all request paths are updated to use the `tenantId` instead of in the request body. `/auth/link` becomes `/tenants/${tenantId}/auth/link`, and so on and so forth. Tests are also updated accordingly.

## Motivation

As Sidecar is creeping closer to GA, we need to route requests through the ALB by the request path, not the request body. We need to adopt this pattern as the recommended standard for a quick and easy implementation of Sidecar for our partners.