### PR TITLE
DEV-1444 Pass linkType to the API for login with email link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,11 @@ function init(tenantId, opts = {}) {
     axios.defaults.headers.common["x-origin"] = url;
   }
 
+  axios.defaults.headers.common["x-userfront-source"] = "core-js";
+  if (opts.userfrontSource) {
+    axios.defaults.headers.common["x-userfront-source"] = opts.userfrontSource;
+  }
+
   setTokenNames();
   setTokensFromCookies();
 

--- a/src/link.js
+++ b/src/link.js
@@ -11,6 +11,7 @@ import { getPkceRequestQueryParams } from "./pkce.js";
  * in the URL querystring. ?token=...&uuid=...
  * @property {String} token
  * @property {UUID} uuid
+ * @property {string} linkType the type of link being used
  * @property {String} redirect - do not redirect if false, or redirect to given path
  * @property {Function} handleUpstreamResponse
  * @property {Function} handleMfaRequired
@@ -21,6 +22,7 @@ import { getPkceRequestQueryParams } from "./pkce.js";
 export async function loginWithLink({
   token,
   uuid,
+  linkType,
   redirect,
   handleUpstreamResponse,
   handleMfaRequired,
@@ -40,6 +42,7 @@ export async function loginWithLink({
       {
         token,
         uuid,
+        linkType,
       },
       {
         headers: getMfaHeaders(),

--- a/src/login.js
+++ b/src/login.js
@@ -46,6 +46,7 @@ export async function login({
   // Link
   token,
   uuid,
+  linkType,
   // Totp
   totpCode,
   backupCode,
@@ -112,6 +113,7 @@ export async function login({
       return loginWithLink({
         token,
         uuid,
+        linkType,
         redirect,
         handleUpstreamResponse,
         handleMfaRequired,


### PR DESCRIPTION
Review level: Glance
Resolves: DEV-1444

Be able to receive the `linkType` parameter and pass it on to the API so that we can redirect to the `afterSignupPath` for new users and the `afterLoginPath` for existing users.