### PR TITLE
[DEV-1574] options.noSignupEmail for signup()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@userfront/core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@userfront/core",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "axios": "1.7.7",
         "js-cookie": "2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@userfront/core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Userfront core JS library",
   "source": "src/index.js",
   "main": "build/userfront-core.js",

--- a/src/login.js
+++ b/src/login.js
@@ -33,6 +33,9 @@ import { setupPkce } from "./pkce.js";
  * @property {Function} handleTokens
  * @property {Function} handleRedirect
  * @property {Object} options
+ * @property {Boolean} options.noResetEmail
+ *  By default, Userfront sends a password reset email if a user without a password tries to log in with a password.
+ *  Set options.noResetEmail = true to override this behavior and return an error instead.
  */
 export async function login({
   method,

--- a/src/password.js
+++ b/src/password.js
@@ -21,6 +21,10 @@ import { getPkceRequestQueryParams } from "./pkce.js";
  * @property {Function} handlePkceRequired
  * @property {Function} handleTokens
  * @property {Function} handleRedirect
+ * @property {Object} options
+ * @property {Boolean} options.noSignupEmail
+ *  By default, Userfront sends a welcome and signup email when registering a new user.
+ *  Set options.noSignupEmail = true to override this behavior.
  */
 export async function signupWithPassword({
   username,
@@ -34,6 +38,7 @@ export async function signupWithPassword({
   handlePkceRequired,
   handleTokens,
   handleRedirect,
+  options,
 } = {}) {
   try {
     const { tenantId } = store;
@@ -45,6 +50,7 @@ export async function signupWithPassword({
         email,
         password,
         data: userData,
+        ...(options?.noSignupEmail && { options: { noSignupEmail: true } }),
       },
       {
         headers: getMfaHeaders(),

--- a/src/signup.js
+++ b/src/signup.js
@@ -22,6 +22,10 @@ import { setupPkce } from "./pkce.js";
  * @property {Function} handlePkceRequired
  * @property {Function} handleTokens
  * @property {Function} handleRedirect
+ * @property {Object} options
+ * @property {Boolean} options.noSignupEmail
+ *  By default, Userfront sends a welcome and signup email when registering a new user.
+ *  Set options.noSignupEmail = true to override this behavior.
  */
 export async function signup({
   method,
@@ -42,6 +46,7 @@ export async function signup({
   handlePkceRequired,
   handleTokens,
   handleRedirect,
+  options,
 } = {}) {
   setupPkce();
   if (!method) {
@@ -71,6 +76,7 @@ export async function signup({
         handlePkceRequired,
         handleTokens,
         handleRedirect,
+        options,
       });
     case "passwordless":
       return sendPasswordlessLink({ email, name, username, userData: data });

--- a/ts/index.d.ts
+++ b/ts/index.d.ts
@@ -5,7 +5,10 @@ interface InitOptions {
   userfrontSource?: string;
   supressNodeWarning?: boolean;
 }
-export declare function init(tenantId: string, options?: InitOptions): Promise<void>;
+export declare function init(
+  tenantId: string,
+  options?: InitOptions
+): Promise<void>;
 
 // addInitCallback()
 export declare function addInitCallback(callback: Function): void;
@@ -163,6 +166,7 @@ export declare function signup({
   handlePkceRequired,
   handleTokens,
   handleRedirect,
+  options,
 }: {
   method: string;
   email?: string;
@@ -178,6 +182,9 @@ export declare function signup({
   handlePkceRequired?: Function;
   handleTokens?: Function;
   handleRedirect?: Function;
+  options?: {
+    noSignupEmail?: boolean;
+  };
 }): Promise<SignupResponse>;
 
 // login()


### PR DESCRIPTION
According to https://userfront.com/docs/api-client#sign-up-with-password, we should be able to add an option for `noSignupEmail` to `signup()`.